### PR TITLE
feat: Add builder to make adding api routes easier

### DIFF
--- a/backend/Api/RouteGroupBuilderExtensions.cs
+++ b/backend/Api/RouteGroupBuilderExtensions.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace backend.Api;
+
+public static class RouteGroupBuilderExtensions
+{
+    public static RouteGroupBuilder MapApiGroup(this IEndpointRouteBuilder endpoints,
+        [StringSyntax("Route")] string routePrefix, string? groupTag = null)
+    {
+        var group = endpoints
+            .MapGroup(routePrefix)
+            .WithOpenApi();
+
+        if (groupTag is not null)
+            group.WithTags(groupTag);
+
+        return group;
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -39,7 +39,10 @@ builder.Services.AddSwaggerGen(c =>
 });
 
 var app = builder.Build();
-app.RegisterConsultantApi();
+
+app.MapApiGroup("variant", "Varianter")
+    .MapConsultantApi();
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsProduction())
 {

--- a/backend/backend.sln.DotSettings
+++ b/backend/backend.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Varianter/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Also in this PR:

- Remove pseudo-constructor from record type and use mapper method instead
- TypedResults for extra type safety and snacks in Swagger 😍
  - Also makes you explicitly return `201 Created`, `404 Not found`, and such

Before: 

![image](https://github.com/varianter/vibes/assets/39614013/3d67d94c-a95a-49d5-9d6e-f37c5d4075d6)

After:

![image](https://github.com/varianter/vibes/assets/39614013/70e56af2-4aa9-42c2-ab13-f97b50955712)
