### PR TITLE
Docker build fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,13 @@
 version: '3.5'
 
 services:
-  # frontend:
-  #   build:
-  #     context: .
-  #     dockerfile: ./frontend/Dockerfile
-  #   container_name: vibes-frontend
-  #   ports:
-  #     - '3000:3000'
-  #   volumes:
-  #     - ./frontend:/app
-  #     - /frontend/app/node_modules
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: ./Dockerfile
+    container_name: vibes-frontend
+    ports:
+      - '3000:3000'
   database:
     image: mcr.microsoft.com/azure-sql-edge
     ports:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+README.md
+LICENSE
+.vscode
+.next
+build
+*.swp
+/scripts
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,20 +7,15 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY yarn.lock*  ./
+COPY yarn.lock* package.json ./
 RUN yarn --frozen-lockfile --ignore-scripts;
 
 
 # Rebuild the source code only when needed
 FROM base AS builder
-WORKDIR /app
+WORKDIR /bundle
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN yarn build
 
@@ -38,7 +33,7 @@ ENV NODE_ENV production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public
+COPY --from=builder /bundle/public ./public
 
 # Set the correct permission for prerender cache
 RUN mkdir .next
@@ -46,8 +41,8 @@ RUN chown nextjs:nodejs .next
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /bundle/build/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /bundle/build/static ./build/static
 
 USER nextjs
 


### PR DESCRIPTION
* Sets correct directory
* Ignores un-needed files on frontend-build
* Points to correct build dir
* Sets proper context

Tested OK with local build with docker.
Note that this file is not currently used in production, which uses App Services (Azure)