### PR TITLE
Fix bug with old hours not updating

### DIFF
--- a/frontend/src/components/ConsultantRow.tsx
+++ b/frontend/src/components/ConsultantRow.tsx
@@ -493,7 +493,7 @@ function DetailedBookingCell({
 }) {
   const { setConsultants } = useContext(FilteredContext);
   const [hours, setHours] = useState(detailedBookingHours.hours);
-  const [oldHours] = useState(detailedBookingHours.hours);
+  const [oldHours, setOldHours] = useState(detailedBookingHours.hours);
   const { setIsDisabledHotkeys } = useContext(FilteredContext);
   const router = useRouter();
 
@@ -513,12 +513,13 @@ function DetailedBookingCell({
         consultant.id,
         detailedBooking.bookingDetails.projectId,
         detailedBookingHours.week,
-      ).then((res) =>
+      ).then((res) => {
         setConsultants((old) => [
           // Use spread to make a new list, forcing a re-render
           ...upsertConsultantWithSingleWeekBooking(old, res),
-        ]),
-      );
+        ]);
+        setOldHours(hourDragValue ?? hours);
+      });
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug where old hours does not update correctly causing the displayed hour value to be wrong unless you refresh the page