### PR TITLE
Fix staffing sum and week selection comments

### DIFF
--- a/frontend/src/components/StaffingSums.tsx
+++ b/frontend/src/components/StaffingSums.tsx
@@ -56,11 +56,7 @@ export default function StaffingSums({
         {weeklyInvoiceRatesArray.map((indexRates, index) => (
           <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
             <p className="small-medium text-right">
-              {Math.floor(indexRates * 100).toLocaleString("nb-No", {
-                maximumFractionDigits: 1,
-                minimumFractionDigits: 1,
-              })}
-              %
+              {Math.round(indexRates * 100)}%
             </p>
           </td>
         ))}

--- a/frontend/src/components/StaffingSums.tsx
+++ b/frontend/src/components/StaffingSums.tsx
@@ -23,7 +23,12 @@ export default function StaffingSums({
         </td>
         {totalBillableHours.map((totalBillableHour, index) => (
           <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-            <p className="small-medium text-right">{totalBillableHour}</p>
+            <p className="small-medium text-right">
+              {totalBillableHour.toLocaleString("nb-No", {
+                maximumFractionDigits: 1,
+                minimumFractionDigits: 1,
+              })}
+            </p>
           </td>
         ))}
       </tr>
@@ -35,7 +40,10 @@ export default function StaffingSums({
           (totalBillableAndOfferedHour, index) => (
             <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
               <p className="small-medium text-right">
-                {totalBillableAndOfferedHour}
+                {totalBillableAndOfferedHour.toLocaleString("nb-No", {
+                  maximumFractionDigits: 1,
+                  minimumFractionDigits: 1,
+                })}
               </p>
             </td>
           ),
@@ -48,7 +56,11 @@ export default function StaffingSums({
         {weeklyInvoiceRatesArray.map((indexRates, index) => (
           <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
             <p className="small-medium text-right">
-              {Math.floor(indexRates * 100)}
+              {Math.floor(indexRates * 100).toLocaleString("nb-No", {
+                maximumFractionDigits: 1,
+                minimumFractionDigits: 1,
+              })}
+              %
             </p>
           </td>
         ))}

--- a/frontend/src/components/WeekSelection.tsx
+++ b/frontend/src/components/WeekSelection.tsx
@@ -22,16 +22,13 @@ export default function WeekSelection() {
 
   return (
     <div className="flex flex-row gap-2">
-      <LargeModal />
-      <ButtonExampleModal />
-
       <DropDown
         startingOption={weekSpan ? weekSpan + " uker" : weekSpanOptions[0]}
         dropDownOptions={weekSpanOptions}
         dropDownFunction={setWeekSpan}
       />
       <ActionButton variant="secondary" onClick={resetSelectedWeek}>
-        Denne uka
+        Nåværende uke
       </ActionButton>
       <IconSecondaryButton
         icon={<ArrowLeft size={24} />}


### PR DESCRIPTION
Fixes two comments from PO and removes large modal and example button buttons from week selector.
![image](https://github.com/varianter/vibes/assets/55406589/49d162bb-f895-4364-9bd7-b4490c1ebdc4)
![image](https://github.com/varianter/vibes/assets/55406589/3855cf0d-1b3c-4c1e-8a39-49fd2cfe3089)
