### PR TITLE
Hide dates when showing 26 weeks or more

### DIFF
--- a/frontend/src/components/FilteredConsultantsList.tsx
+++ b/frontend/src/components/FilteredConsultantsList.tsx
@@ -57,15 +57,29 @@ export default function FilteredConsultantList() {
                 {isCurrentWeek(booking.weekNumber, booking.year) ? (
                   <div className="flex flex-row gap-2 items-center justify-end">
                     <div className="h-2 w-2 rounded-full bg-primary" />
-                    <p className="normal-medium text-right">
+                    <p
+                      className={`normal-medium ${
+                        weekSpan >= 26 ? "text-center" : "text-right"
+                      }`}
+                    >
                       {booking.weekNumber}
                     </p>
                   </div>
                 ) : (
-                  <p className="normal text-right">{booking.weekNumber}</p>
+                  <p
+                    className={`normal ${
+                      weekSpan >= 26 ? "text-center" : "text-right"
+                    }`}
+                  >
+                    {booking.weekNumber}
+                  </p>
                 )}
 
-                <p className="xsmall text-black/75 text-right">
+                <p
+                  className={`xsmall text-black/75 text-right ${
+                    weekSpan >= 26 && "hidden"
+                  }`}
+                >
                   {booking.dateString}
                 </p>
               </th>

--- a/frontend/src/components/FilteredConsultantsList.tsx
+++ b/frontend/src/components/FilteredConsultantsList.tsx
@@ -84,9 +84,7 @@ export default function FilteredConsultantList() {
                           variant={weekSpan < 24 ? "wide" : "medium"}
                         />
                       )}
-                      <p className="normal-medium text-right">
-                        {booking.weekNumber}
-                      </p>
+                      <p className="normal text-right">{booking.weekNumber}</p>
                     </div>
                   )}
 

--- a/frontend/src/components/FilteredConsultantsList.tsx
+++ b/frontend/src/components/FilteredConsultantsList.tsx
@@ -68,11 +68,7 @@ export default function FilteredConsultantList() {
                       )}
                       <div className="h-2 w-2 rounded-full bg-primary" />
 
-                      <p
-                        className={`normal-medium ${
-                          weekSpan >= 26 ? "text-center" : "text-right"
-                        }`}
-                      >
+                      <p className="normal-medium text-right">
                         {booking.weekNumber}
                       </p>
                     </div>
@@ -88,11 +84,7 @@ export default function FilteredConsultantList() {
                           variant={weekSpan < 24 ? "wide" : "medium"}
                         />
                       )}
-                      <p
-                        className={`normal-medium ${
-                          weekSpan >= 26 ? "text-center" : "text-right"
-                        }`}
-                      >
+                      <p className="normal-medium text-right">
                         {booking.weekNumber}
                       </p>
                     </div>


### PR DESCRIPTION
Closes #333

Denne PR-en sørger for at datoene i uka blir skjult når det er 26 uker eller mer som vises i tabellen. Foreløpig blir uketallet kun sentrert på 26 uker eller mer, siden helligdag infopillen skal vises ved siden av uketallet ved færre antall uker. Det kan hende dette blir endret når det blir tatt et valg på hvordan den infopillen skal vises på 26 uker (derfor draft enda) 


<img width="1438" alt="Skjermbilde 2023-11-29 kl  11 05 02" src="https://github.com/varianter/vibes/assets/69193134/036f9f9a-74fd-4f3d-a993-b38c26d38c43">
