### PR TITLE
Temporary fix for overlapping week number and infopill

### DIFF
--- a/frontend/src/components/FilteredConsultantsList.tsx
+++ b/frontend/src/components/FilteredConsultantsList.tsx
@@ -73,7 +73,13 @@ export default function FilteredConsultantList() {
                       </p>
                     </div>
                   ) : (
-                    <div className="flex flex-row gap-2 justify-end">
+                    <div
+                      className={`flex justify-end ${
+                        weekSpan >= 26
+                          ? "min-h-[30px] flex-col mb-2 gap-[1px] items-end"
+                          : "flex-row gap-2"
+                      }`}
+                    >
                       {booking.bookingModel.totalHolidayHours > 0 && (
                         <InfoPill
                           text={booking.bookingModel.totalHolidayHours.toFixed(


### PR DESCRIPTION
Denne PR-en lager en midlertidig fix som unngår at ferie-infopillen overlapper uketallene når 26 uker vises i tabellen: 

<img width="1460" alt="Skjermbilde 2023-11-29 kl  15 00 54" src="https://github.com/varianter/vibes/assets/69193134/dac4adfa-32df-4550-ad83-0ad5513fd096">
