### PR TITLE
372 engagement modal

### DIFF
--- a/frontend/src/components/Buttons/ActionButton.tsx
+++ b/frontend/src/components/Buttons/ActionButton.tsx
@@ -31,13 +31,18 @@ export default function ActionButton({
 }: ActionButtonProps) {
   const variantClass =
     {
-      primary: "bg-primary text-white hover:bg-primary_darker",
-      secondary:
-        "bg-white text-primary border border-primary/50 hover:bg-primary/10 hover:border-primary",
-      terniary: "bg-white text-primary hover:bg-primary/10",
+      primary: `bg-primary text-white ${
+        !disabled && "hover:bg-primary_darker"
+      }`,
+      secondary: `bg-white text-primary border border-primary/50 ${
+        !disabled && "hover:border-primary"
+      }`,
+      terniary: `bg-white text-primary ${
+        !disabled && "hover:bg-primary/10 hover:bg-primary/10"
+      }`,
     }[variant] ?? "Default";
 
-  const disabledClass = disabled ? "bg-opacity-50" : "";
+  const disabledClass = disabled ? "bg-opacity-50 cursor-default" : "";
   const fullWidthClass = fullWidth ? "w-full" : "";
   const buttonShapeClass = iconBtn
     ? small
@@ -47,8 +52,8 @@ export default function ActionButton({
 
   return (
     <BaseButton
-      className={` ${variantClass} ${disabledClass} ${fullWidthClass} ${buttonShapeClass} ${className}`}
-      onClick={onClick}
+      className={`${variantClass} ${disabledClass} ${fullWidthClass} ${buttonShapeClass} ${className}`}
+      onClick={() => !disabled && onClick}
       type={type}
     >
       <IconBox small={small}>{iconLeft}</IconBox>

--- a/frontend/src/components/Modals/BaseModal.tsx
+++ b/frontend/src/components/Modals/BaseModal.tsx
@@ -12,7 +12,10 @@ function BaseModal(props: BaseModalProps) {
   const { children, modalRef, classNames } = props;
 
   return (
-    <dialog ref={modalRef} className={`rounded-lg p-4 ${classNames}`}>
+    <dialog
+      ref={modalRef}
+      className={`rounded-lg p-4 overflow-visible ${classNames}`}
+    >
       {children}
     </dialog>
   );

--- a/frontend/src/components/ReactSelect.tsx
+++ b/frontend/src/components/ReactSelect.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
+import { useContext } from "react";
 import Select, { MultiValue } from "react-select";
 
 export type SelectOption = { value: string; label: string };
@@ -10,6 +11,8 @@ export default function ReactSelect({
   onSingleOptionChange,
   onMultipleOptionsChange,
   isMultipleOptions = false,
+  isDisabled = false,
+  placeHolderText = "Velg...",
 }: {
   options: SelectOption[];
   selectedSingleOptionValue?: SelectOption | null;
@@ -17,11 +20,19 @@ export default function ReactSelect({
   onSingleOptionChange?: (arg: SelectOption) => void;
   onMultipleOptionsChange?: (arg: MultiValue<SelectOption>) => void;
   isMultipleOptions?: boolean;
+  isDisabled?: boolean;
+  placeHolderText?: string;
 }) {
+  const { setCloseModalOnBackdropClick } = useContext(FilteredContext);
+
   return (
     <Select
+      onFocus={() => setCloseModalOnBackdropClick(false)}
+      onBlur={() => setCloseModalOnBackdropClick(true)}
+      placeholder={placeHolderText}
       isMulti={isMultipleOptions}
       options={options}
+      isDisabled={isDisabled}
       value={
         isMultipleOptions
           ? selectedMultipleOptionsValue
@@ -32,7 +43,24 @@ export default function ReactSelect({
           ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
           : onSingleOptionChange?.(a as SelectOption);
       }}
-      classNames={{ menu: () => "max-h-[120px] bg-white overflow-hidden" }}
+      styles={{
+        valueContainer: (base) => ({
+          ...base,
+          overflowX: "scroll",
+          flexWrap: "unset",
+          "::-webkit-scrollbar": {
+            display: "none",
+          },
+        }),
+        multiValue: (base) => ({
+          ...base,
+          flex:
+            selectedMultipleOptionsValue?.length &&
+            selectedMultipleOptionsValue?.length >= 2
+              ? "1 0 auto"
+              : "",
+        }),
+      }}
     />
   );
 }

--- a/frontend/src/components/Staffing/AddEngagementForm.tsx
+++ b/frontend/src/components/Staffing/AddEngagementForm.tsx
@@ -158,22 +158,6 @@ export function AddEngagementForm({
           <form onSubmit={handleSubmit}>
             <div className="flex flex-col gap-6 pt-6 h-96">
               {/* Selected Customer */}
-              <div className="flex flex-col gap-2">
-                <p className="small text-black">Konsulenter</p>
-                <ReactSelect
-                  options={consultantOptions}
-                  selectedMultipleOptionsValue={selectedConsultants}
-                  onMultipleOptionsChange={setSelectedConsultants}
-                  isMultipleOptions={true}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <p className="small text-black">Kunde</p>
-                <ReactSelect
-                  options={customerOptions}
-                  selectedSingleOptionValue={selectedCustomer}
-                  onSingleOptionChange={handleSelectedCustomerChange}
-                  isMultipleOptions={false}
                 />
               </div>
               <div className="flex flex-col gap-2">

--- a/frontend/src/components/Staffing/AddStaffingCell.tsx
+++ b/frontend/src/components/Staffing/AddStaffingCell.tsx
@@ -1,11 +1,18 @@
-import React, { ReactElement, useState } from "react";
+import React, { ReactElement, useContext, useState } from "react";
 import { useModal } from "@/hooks/useModal";
 import { AddEngagementForm } from "@/components/Staffing/AddEngagementForm";
 import { Plus } from "react-feather";
+import { Consultant } from "@/types";
+import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 
-export function AddStaffingCell(): ReactElement {
+export function AddStaffingCell({
+  consultant,
+}: {
+  consultant: Consultant;
+}): ReactElement {
+  const { closeModalOnBackdropClick } = useContext(FilteredContext);
   const { closeModal, openModal, modalRef } = useModal({
-    closeOnBackdropClick: true,
+    closeOnBackdropClick: closeModalOnBackdropClick,
   });
   const [isAddStaffingHovered, setIsAddStaffingHovered] = useState(false);
 
@@ -16,6 +23,7 @@ export function AddStaffingCell(): ReactElement {
         <AddEngagementForm
           closeEngagementModal={closeModal}
           easyModalRef={modalRef}
+          consultant={consultant}
         />
 
         <button

--- a/frontend/src/components/Staffing/ConsultantRow.tsx
+++ b/frontend/src/components/Staffing/ConsultantRow.tsx
@@ -86,7 +86,7 @@ export default function ConsultantRows({
         ))}
       {isListElementVisible && (
         <tr>
-          <AddStaffingCell />
+          <AddStaffingCell consultant={consultant} />
         </tr>
       )}
     </>

--- a/frontend/src/hooks/ConsultantFilterProvider.tsx
+++ b/frontend/src/hooks/ConsultantFilterProvider.tsx
@@ -12,8 +12,10 @@ type FilterContextType = {
   setConsultants: React.Dispatch<React.SetStateAction<Consultant[]>>;
   departments: Department[];
   customers: EngagementPerCustomerReadModel[];
-  isDisabledHotkeys: Boolean;
+  isDisabledHotkeys: boolean;
   setIsDisabledHotkeys: React.Dispatch<React.SetStateAction<boolean>>;
+  closeModalOnBackdropClick: boolean;
+  setCloseModalOnBackdropClick: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const FilteredContext = createContext<FilterContextType>({
@@ -23,6 +25,8 @@ export const FilteredContext = createContext<FilterContextType>({
   customers: [],
   isDisabledHotkeys: false,
   setIsDisabledHotkeys: () => {},
+  closeModalOnBackdropClick: true,
+  setCloseModalOnBackdropClick: () => {},
 });
 
 export function ConsultantFilterProvider(props: {
@@ -32,6 +36,8 @@ export function ConsultantFilterProvider(props: {
   children: ReactNode;
 }) {
   const [isDisabledHotkeys, setIsDisabledHotkeys] = useState(false);
+  const [closeModalOnBackdropClick, setCloseModalOnBackdropClick] =
+    useState(true);
   const [consultants, setConsultants] = useState(props.consultants ?? []);
 
   useEffect(() => setConsultants(props.consultants), [props.consultants]);
@@ -42,6 +48,8 @@ export function ConsultantFilterProvider(props: {
         ...props,
         isDisabledHotkeys,
         setIsDisabledHotkeys,
+        closeModalOnBackdropClick,
+        setCloseModalOnBackdropClick,
         consultants,
         setConsultants,
       }}


### PR DESCRIPTION
Closes #372 

Denne PR-en implementerer riktig flyt og funksjonalitet på "Legg til nytt engasjement"-modalen. Den legger til en state i context for å få global state for å aktivere/deaktivere lukking av modal når man klikker utenfor modalen, disabling av combobox og action button, horisontal scrolling i multi option react select og at konsulenten man trykker på blir automatisk valgt i modalen. 

<img width="386" alt="Skjermbilde 2023-12-08 kl  08 10 52" src="https://github.com/varianter/vibes/assets/69193134/46d457c1-7161-4fb4-8388-8e4f1f2f9436">
<img width="400" alt="Skjermbilde 2023-12-08 kl  08 11 07" src="https://github.com/varianter/vibes/assets/69193134/81989fbb-89e1-4da4-85f2-f4430df83e68">
