### PR TITLE
385 creatable select

### DIFF
--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -1,6 +1,7 @@
 import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 import { useContext } from "react";
 import Select, { MultiValue } from "react-select";
+import CreatableSelect from "react-select/creatable";
 
 export type SelectOption = { value: string | number; label: string };
 
@@ -28,7 +29,7 @@ export default function ComboBox({
   const { setCloseModalOnBackdropClick } = useContext(FilteredContext);
 
   return (
-    <Select
+    <CreatableSelect
       onFocus={() => setCloseModalOnBackdropClick(false)}
       onBlur={() => setCloseModalOnBackdropClick(true)}
       placeholder={placeHolderText}

--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -1,6 +1,6 @@
 import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 import { useContext } from "react";
-import Select, { MultiValue } from "react-select";
+import { MultiValue, createFilter } from "react-select";
 import CreatableSelect from "react-select/creatable";
 
 export type SelectOption = { value: string | number; label: string };
@@ -27,6 +27,9 @@ export default function ComboBox({
   isClearable?: boolean;
 }) {
   const { setCloseModalOnBackdropClick } = useContext(FilteredContext);
+  const customFilter = createFilter({
+    matchFrom: "start",
+  });
 
   return (
     <CreatableSelect
@@ -37,6 +40,7 @@ export default function ComboBox({
       options={options}
       isDisabled={isDisabled}
       isClearable={isClearable}
+      filterOption={customFilter}
       value={
         isMultipleOptions
           ? selectedMultipleOptionsValue

--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -41,6 +41,7 @@ export default function ComboBox({
       isDisabled={isDisabled}
       isClearable={isClearable}
       filterOption={customFilter}
+      formatCreateLabel={(inputText) => `Legg til "${inputText}"`}
       value={
         isMultipleOptions
           ? selectedMultipleOptionsValue

--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -1,6 +1,6 @@
 import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 import { useContext } from "react";
-import Select, { MultiValue, createFilter } from "react-select";
+import Select, { MultiValue, SingleValue, createFilter } from "react-select";
 import CreatableSelect from "react-select/creatable";
 
 export type SelectOption = { value: string | number; label: string };
@@ -33,88 +33,48 @@ export default function ComboBox({
     matchFrom: "start",
   });
 
-  if (!isCreatable) {
-    return (
-      <Select
-        onFocus={() => setCloseModalOnBackdropClick(false)}
-        onBlur={() => setCloseModalOnBackdropClick(true)}
-        placeholder={placeHolderText}
-        isMulti={isMultipleOptions}
-        options={options}
-        isDisabled={isDisabled}
-        isClearable={isClearable}
-        filterOption={customFilter}
-        value={
-          isMultipleOptions
-            ? selectedMultipleOptionsValue
-            : selectedSingleOptionValue
-        }
-        onChange={(a) => {
-          a && isMultipleOptions
-            ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
-            : onSingleOptionChange?.(a as SelectOption);
-        }}
-        styles={{
-          valueContainer: (base) => ({
-            ...base,
-            overflowX: "scroll",
-            flexWrap: "unset",
-            "::-webkit-scrollbar": {
-              display: "none",
-            },
-          }),
-          multiValue: (base) => ({
-            ...base,
-            flex:
-              selectedMultipleOptionsValue?.length &&
-              selectedMultipleOptionsValue?.length >= 2
-                ? "1 0 auto"
-                : "",
-          }),
-        }}
-      />
-    );
-  } else {
+  const selectProps = {
+    onFocus: () => setCloseModalOnBackdropClick(false),
+    onBlur: () => setCloseModalOnBackdropClick(true),
+    placeholder: placeHolderText,
+    isMulti: isMultipleOptions,
+    options: options,
+    isDisabled: isDisabled,
+    isClearable: isClearable,
+    filterOption: customFilter,
+    value: isMultipleOptions
+      ? selectedMultipleOptionsValue
+      : selectedSingleOptionValue,
+    onChange: (a: MultiValue<SelectOption> | SingleValue<SelectOption>) => {
+      a && isMultipleOptions
+        ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
+        : onSingleOptionChange?.(a as SelectOption);
+    },
+    styles: {
+      valueContainer: (base: any) => ({
+        ...base,
+        overflowX: "scroll",
+        flexWrap: "unset",
+        "::-webkit-scrollbar": {
+          display: "none",
+        },
+      }),
+      multiValue: (base: any) => ({
+        ...base,
+        flex:
+          selectedMultipleOptionsValue?.length &&
+          selectedMultipleOptionsValue?.length >= 2
+            ? "1 0 auto"
+            : "",
+      }),
+    },
+  };
+  if (!isCreatable) return <Select {...selectProps} />;
+  else
     return (
       <CreatableSelect
-        onFocus={() => setCloseModalOnBackdropClick(false)}
-        onBlur={() => setCloseModalOnBackdropClick(true)}
-        placeholder={placeHolderText}
-        isMulti={isMultipleOptions}
-        options={options}
-        isDisabled={isDisabled}
-        isClearable={isClearable}
-        filterOption={customFilter}
-        formatCreateLabel={(inputText) => `Legg til "${inputText}"`}
-        value={
-          isMultipleOptions
-            ? selectedMultipleOptionsValue
-            : selectedSingleOptionValue
-        }
-        onChange={(a) => {
-          a && isMultipleOptions
-            ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
-            : onSingleOptionChange?.(a as SelectOption);
-        }}
-        styles={{
-          valueContainer: (base) => ({
-            ...base,
-            overflowX: "scroll",
-            flexWrap: "unset",
-            "::-webkit-scrollbar": {
-              display: "none",
-            },
-          }),
-          multiValue: (base) => ({
-            ...base,
-            flex:
-              selectedMultipleOptionsValue?.length &&
-              selectedMultipleOptionsValue?.length >= 2
-                ? "1 0 auto"
-                : "",
-          }),
-        }}
+        {...selectProps}
+        formatCreateLabel={(inputText: string) => `Legg til "${inputText}"`}
       />
     );
-  }
 }

--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -1,6 +1,6 @@
 import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 import { useContext } from "react";
-import { MultiValue, createFilter } from "react-select";
+import Select, { MultiValue, createFilter } from "react-select";
 import CreatableSelect from "react-select/creatable";
 
 export type SelectOption = { value: string | number; label: string };
@@ -15,6 +15,7 @@ export default function ComboBox({
   isDisabled = false,
   placeHolderText = "Velg...",
   isClearable = false,
+  isCreatable = false,
 }: {
   options: SelectOption[];
   selectedSingleOptionValue?: SelectOption | null;
@@ -25,51 +26,95 @@ export default function ComboBox({
   isDisabled?: boolean;
   placeHolderText?: string;
   isClearable?: boolean;
+  isCreatable?: boolean;
 }) {
   const { setCloseModalOnBackdropClick } = useContext(FilteredContext);
   const customFilter = createFilter({
     matchFrom: "start",
   });
 
-  return (
-    <CreatableSelect
-      onFocus={() => setCloseModalOnBackdropClick(false)}
-      onBlur={() => setCloseModalOnBackdropClick(true)}
-      placeholder={placeHolderText}
-      isMulti={isMultipleOptions}
-      options={options}
-      isDisabled={isDisabled}
-      isClearable={isClearable}
-      filterOption={customFilter}
-      formatCreateLabel={(inputText) => `Legg til "${inputText}"`}
-      value={
-        isMultipleOptions
-          ? selectedMultipleOptionsValue
-          : selectedSingleOptionValue
-      }
-      onChange={(a) => {
-        a && isMultipleOptions
-          ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
-          : onSingleOptionChange?.(a as SelectOption);
-      }}
-      styles={{
-        valueContainer: (base) => ({
-          ...base,
-          overflowX: "scroll",
-          flexWrap: "unset",
-          "::-webkit-scrollbar": {
-            display: "none",
-          },
-        }),
-        multiValue: (base) => ({
-          ...base,
-          flex:
-            selectedMultipleOptionsValue?.length &&
-            selectedMultipleOptionsValue?.length >= 2
-              ? "1 0 auto"
-              : "",
-        }),
-      }}
-    />
-  );
+  if (!isCreatable) {
+    return (
+      <Select
+        onFocus={() => setCloseModalOnBackdropClick(false)}
+        onBlur={() => setCloseModalOnBackdropClick(true)}
+        placeholder={placeHolderText}
+        isMulti={isMultipleOptions}
+        options={options}
+        isDisabled={isDisabled}
+        isClearable={isClearable}
+        filterOption={customFilter}
+        value={
+          isMultipleOptions
+            ? selectedMultipleOptionsValue
+            : selectedSingleOptionValue
+        }
+        onChange={(a) => {
+          a && isMultipleOptions
+            ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
+            : onSingleOptionChange?.(a as SelectOption);
+        }}
+        styles={{
+          valueContainer: (base) => ({
+            ...base,
+            overflowX: "scroll",
+            flexWrap: "unset",
+            "::-webkit-scrollbar": {
+              display: "none",
+            },
+          }),
+          multiValue: (base) => ({
+            ...base,
+            flex:
+              selectedMultipleOptionsValue?.length &&
+              selectedMultipleOptionsValue?.length >= 2
+                ? "1 0 auto"
+                : "",
+          }),
+        }}
+      />
+    );
+  } else {
+    return (
+      <CreatableSelect
+        onFocus={() => setCloseModalOnBackdropClick(false)}
+        onBlur={() => setCloseModalOnBackdropClick(true)}
+        placeholder={placeHolderText}
+        isMulti={isMultipleOptions}
+        options={options}
+        isDisabled={isDisabled}
+        isClearable={isClearable}
+        filterOption={customFilter}
+        formatCreateLabel={(inputText) => `Legg til "${inputText}"`}
+        value={
+          isMultipleOptions
+            ? selectedMultipleOptionsValue
+            : selectedSingleOptionValue
+        }
+        onChange={(a) => {
+          a && isMultipleOptions
+            ? onMultipleOptionsChange?.(a as MultiValue<SelectOption>)
+            : onSingleOptionChange?.(a as SelectOption);
+        }}
+        styles={{
+          valueContainer: (base) => ({
+            ...base,
+            overflowX: "scroll",
+            flexWrap: "unset",
+            "::-webkit-scrollbar": {
+              display: "none",
+            },
+          }),
+          multiValue: (base) => ({
+            ...base,
+            flex:
+              selectedMultipleOptionsValue?.length &&
+              selectedMultipleOptionsValue?.length >= 2
+                ? "1 0 auto"
+                : "",
+          }),
+        }}
+      />
+    );
+  }
 }

--- a/frontend/src/components/Staffing/AddEngagementForm.tsx
+++ b/frontend/src/components/Staffing/AddEngagementForm.tsx
@@ -202,6 +202,7 @@ export function AddEngagementForm({
                 isMultipleOptions={false}
                 placeHolderText="Velg kunde"
                 isDisabled={!selectedConsultants}
+                isCreatable={true}
               />
             </div>
             <div className="flex flex-col gap-2">
@@ -213,6 +214,7 @@ export function AddEngagementForm({
                 isMultipleOptions={false}
                 placeHolderText="Velg engasjement"
                 isDisabled={selectedCustomer == null}
+                isCreatable={true}
               />
             </div>
             {/* Radio Button Group */}


### PR DESCRIPTION
Closes #385 

Denne PR-en implementerer muligheten til å legge til nye kunder og engasjement i comboboxen. CreateFilter med matchFrom: "start" er brukt for å få prefix-filtrering, altså at "D" kun viser options som starter med D. En `isCreatable` prop er brukt for å hindre at nye konsulenter kan legges til i konsulent-comboboxen. Det blir litt duplikat kode her, siden jeg dessverre ikke fant noen standard props for creatable react select som gjør dette enklere 😅 Gjerne kom med forslag på tilnærminger som kan redusere duplikat kode! 