### PR TITLE
Fix bug with dragging 0 hours in large modal

### DIFF
--- a/frontend/src/components/Staffing/AddEngagementHoursModal/AddEngagementHoursRow.tsx
+++ b/frontend/src/components/Staffing/AddEngagementHoursModal/AddEngagementHoursRow.tsx
@@ -47,7 +47,7 @@ export function AddEngagementHoursRow({
       );
 
       if (hoursForWeek) {
-        hoursForWeek.hours = resHours || hoursForWeek.hours || 0;
+        hoursForWeek.hours = resHours ?? hoursForWeek.hours ?? 0;
       } else {
         consultant.weekWithHours.push({
           week: dayToWeek(d),


### PR DESCRIPTION
Closes #387 

Denne PR-en fikser en bug der draing av 0 timer i stor modal ikke oppdaterer cellene