### PR TITLE
Remove close on click outside modal feature

### DIFF
--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -28,14 +28,11 @@ export default function ComboBox({
   isClearable?: boolean;
   isCreatable?: boolean;
 }) {
-  const { setCloseModalOnBackdropClick } = useContext(FilteredContext);
   const customFilter = createFilter({
     matchFrom: "start",
   });
 
   const selectProps = {
-    onFocus: () => setCloseModalOnBackdropClick(false),
-    onBlur: () => setCloseModalOnBackdropClick(true),
     placeholder: placeHolderText,
     isMulti: isMultipleOptions,
     options: options,

--- a/frontend/src/components/Staffing/AddEngagementHoursModal/AddEngagementHoursModal.tsx
+++ b/frontend/src/components/Staffing/AddEngagementHoursModal/AddEngagementHoursModal.tsx
@@ -90,6 +90,8 @@ export function AddEngagementHoursModal({
       project={project}
       showCloseButton={true}
       onClose={() => {
+        setSelectedConsultantsFirstEdited(false);
+        setSelectedConsultants([]);
         setIsDisabledHotkeys(false), router.refresh();
       }}
     >

--- a/frontend/src/components/Staffing/AddStaffingCell.tsx
+++ b/frontend/src/components/Staffing/AddStaffingCell.tsx
@@ -11,7 +11,6 @@ export function AddStaffingCell({
 }: {
   consultant: ConsultantReadModel;
 }): ReactElement {
-  const { closeModalOnBackdropClick } = useContext(FilteredContext);
   const {
     closeModal: closeAddEngagementModal,
     openModal: openAddEngagementModal,

--- a/frontend/src/components/Staffing/AddStaffingCell.tsx
+++ b/frontend/src/components/Staffing/AddStaffingCell.tsx
@@ -17,7 +17,7 @@ export function AddStaffingCell({
     openModal: openAddEngagementModal,
     modalRef: addEngagementModalRef,
   } = useModal({
-    closeOnBackdropClick: closeModalOnBackdropClick,
+    closeOnBackdropClick: false,
   });
 
   const {
@@ -25,7 +25,7 @@ export function AddStaffingCell({
     openModal: openStaffEngagementModal,
     modalRef: staffEngagementModalRef,
   } = useModal({
-    closeOnBackdropClick: closeModalOnBackdropClick,
+    closeOnBackdropClick: false,
   });
 
   const [isAddStaffingHovered, setIsAddStaffingHovered] = useState(false);

--- a/frontend/src/hooks/ConsultantFilterProvider.tsx
+++ b/frontend/src/hooks/ConsultantFilterProvider.tsx
@@ -14,8 +14,6 @@ type FilterContextType = {
   customers: EngagementPerCustomerReadModel[];
   isDisabledHotkeys: boolean;
   setIsDisabledHotkeys: React.Dispatch<React.SetStateAction<boolean>>;
-  closeModalOnBackdropClick: boolean;
-  setCloseModalOnBackdropClick: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const FilteredContext = createContext<FilterContextType>({
@@ -25,8 +23,6 @@ export const FilteredContext = createContext<FilterContextType>({
   customers: [],
   isDisabledHotkeys: false,
   setIsDisabledHotkeys: () => {},
-  closeModalOnBackdropClick: true,
-  setCloseModalOnBackdropClick: () => {},
 });
 
 export function ConsultantFilterProvider(props: {
@@ -36,8 +32,6 @@ export function ConsultantFilterProvider(props: {
   children: ReactNode;
 }) {
   const [isDisabledHotkeys, setIsDisabledHotkeys] = useState(false);
-  const [closeModalOnBackdropClick, setCloseModalOnBackdropClick] =
-    useState(true);
   const [consultants, setConsultants] = useState(props.consultants ?? []);
 
   useEffect(() => setConsultants(props.consultants), [props.consultants]);
@@ -48,8 +42,6 @@ export function ConsultantFilterProvider(props: {
         ...props,
         isDisabledHotkeys,
         setIsDisabledHotkeys,
-        closeModalOnBackdropClick,
-        setCloseModalOnBackdropClick,
         consultants,
         setConsultants,
       }}


### PR DESCRIPTION
Closes #392 

Denne PR-en fjerner lukking av modal når man trykker utenfor den, siden denne lukkingen medførte seg en del bugs (eks: hotkeys blir ikke aktivert igjen hvis man trykker utenfor den store modalen) 