### PR TITLE
Reset engagement modal values on add engagement

### DIFF
--- a/frontend/src/components/Staffing/AddEngagementForm.tsx
+++ b/frontend/src/components/Staffing/AddEngagementForm.tsx
@@ -150,6 +150,7 @@ export function AddEngagementForm({
         ),
       );
       setIsDisabledHotkeys(true);
+      resetSelectedValues();
 
       // TODO: Futher logic for the changes in openModal *here*
     } else console.error("Error adding engagement");


### PR DESCRIPTION
Closes #399 

Denne PR-en fikser en bug der verdiene valgt i react select ikke nullstilles når man trykker på "Legg til engasjement" og er derfor fortsatt valgt neste gang man åpner modalen