### PR TITLE
Fix bug with invoice rates being negative or over 100%

### DIFF
--- a/frontend/src/hooks/staffing/useConsultantsFilter.ts
+++ b/frontend/src/hooks/staffing/useConsultantsFilter.ts
@@ -187,9 +187,9 @@ function setWeeklyInvoiceRate(
     });
 
     const invoiceRate =
-      totalAvailableWeekHours == 0
+      totalAvailableWeekHours <= 0
         ? 0
-        : totalBillable / totalAvailableWeekHours;
+        : Math.max(0, Math.min(1, totalBillable / totalAvailableWeekHours));
     weeklyInvoiceRate.set(weekNumber, invoiceRate);
   });
 


### PR DESCRIPTION
Closes #398 

Denne PR-en sørger for at faktureringsgraden holdes mellom 0% og 100%.