### PR TITLE
Show '-' in staffing if consultant has not started yet or quit

### DIFF
--- a/frontend/src/components/FilteredConsultantsList.tsx
+++ b/frontend/src/components/FilteredConsultantsList.tsx
@@ -10,6 +10,7 @@ import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 
 export default function StaffingTable() {
   const {
+    numWorkHours,
     filteredConsultants,
     weeklyTotalBillable,
     weeklyTotalBillableAndOffered,
@@ -111,7 +112,11 @@ export default function StaffingTable() {
         </thead>
         <tbody>
           {filteredConsultants.map((consultant) => (
-            <ConsultantRows key={consultant.id} consultant={consultant} />
+            <ConsultantRows
+              key={consultant.id}
+              consultant={consultant}
+              numWorkHours={numWorkHours}
+            />
           ))}
         </tbody>
         <StaffingSums

--- a/frontend/src/components/Staffing/ConsultantRow.tsx
+++ b/frontend/src/components/Staffing/ConsultantRow.tsx
@@ -19,8 +19,10 @@ import { DateTime } from "luxon";
 
 export default function ConsultantRows({
   consultant,
+  numWorkHours,
 }: {
   consultant: ConsultantReadModel;
+  numWorkHours: number;
 }) {
   const [currentConsultant, setCurrentConsultant] =
     useState<ConsultantReadModel>(consultant);
@@ -210,6 +212,7 @@ export default function ConsultantRows({
             columnCount={columnCount}
             isLastCol={index == currentConsultant.bookings.length - 1}
             isSecondLastCol={index == currentConsultant.bookings.length - 2}
+            numWorkHours={numWorkHours}
           />
         ))}
       </tr>

--- a/frontend/src/components/Staffing/WeekCell.tsx
+++ b/frontend/src/components/Staffing/WeekCell.tsx
@@ -15,6 +15,7 @@ export function WeekCell(props: {
   columnCount: number;
   isLastCol: boolean;
   isSecondLastCol: boolean;
+  numWorkHours: number;
 }) {
   const {
     bookedHoursPerWeek: bookedHoursPerWeek,
@@ -26,6 +27,7 @@ export function WeekCell(props: {
     columnCount,
     isLastCol,
     isSecondLastCol,
+    numWorkHours,
   } = props;
 
   let pillNumber = 0;
@@ -152,11 +154,34 @@ export function WeekCell(props: {
             isListElementVisible ? "normal-medium" : "normal"
           }`}
         >
-          {bookedHoursPerWeek.bookingModel.totalBillable.toLocaleString(
-            "nb-No",
-          )}
+          {bookedHoursPerWeek.bookingModel.totalPlannedAbsences > 0 &&
+          checkIfNotStartedOrQuit(consultant, bookedHoursPerWeek, numWorkHours)
+            ? "-"
+            : bookedHoursPerWeek.bookingModel.totalBillable.toLocaleString(
+                "nb-No",
+              )}
         </p>
       </div>
     </td>
+  );
+}
+
+function checkIfNotStartedOrQuit(
+  consultant: ConsultantReadModel,
+  bookedHoursPerWeek: BookedHoursPerWeek,
+  numWorkHours: number,
+) {
+  const project = consultant.detailedBooking.find(
+    (b) => b.bookingDetails.projectName == "Ikke startet eller sluttet",
+  );
+  const hours = project?.hours.find(
+    (h) => h.week == bookedHoursPerWeek.sortableWeek,
+  );
+
+  if (!hours?.hours) return false;
+
+  return (
+    hours?.hours ==
+    numWorkHours - bookedHoursPerWeek.bookingModel.totalHolidayHours
   );
 }

--- a/frontend/src/hooks/staffing/useConsultantsFilter.ts
+++ b/frontend/src/hooks/staffing/useConsultantsFilter.ts
@@ -82,6 +82,7 @@ export function useConsultantsFilter() {
   );
 
   return {
+    numWorkHours,
     filteredConsultants,
     weeklyTotalBillable,
     weeklyTotalBillableAndOffered,


### PR DESCRIPTION
If a consultant has not started yet or quit, show staffing as '-' instead of a number, in order for users to easily identify if a consultant is available for staffing or not. 