### PR TITLE
Fix/add constraints on project name and customer name in db

### DIFF
--- a/backend/Api/Projects/ProjectController.cs
+++ b/backend/Api/Projects/ProjectController.cs
@@ -227,7 +227,7 @@ public class ProjectController : ControllerBase
 
         var project = _context.Project
             .Include(p => p.Customer)
-            .SingleOrDefault(p => p.Customer.Name == body.CustomerName
+            .SingleOrDefault(p => p.Customer.Id == customer.Id
                                   && p.Name == body.ProjectName
             );
 

--- a/backend/Core/DomainModels/Customer.cs
+++ b/backend/Core/DomainModels/Customer.cs
@@ -7,6 +7,8 @@ public class Customer
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
 
+    public string? OrganizationId { get; set; }
+
     public required string Name { get; set; }
     public required Organization Organization { get; set; }
     public required List<Engagement> Projects { get; set; }

--- a/backend/Core/DomainModels/Engagement.cs
+++ b/backend/Core/DomainModels/Engagement.cs
@@ -7,6 +7,8 @@ public class Engagement
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
 
+    public int CustomerId { get; set; }
+
     public required Customer Customer { get; set; }
 
     public required EngagementState State { get; set; }

--- a/backend/Database/DatabaseContext/ApplicationContext.cs
+++ b/backend/Database/DatabaseContext/ApplicationContext.cs
@@ -47,12 +47,21 @@ public class ApplicationContext : DbContext
 
         modelBuilder.Entity<Organization>()
             .HasMany(organization => organization.Customers)
-            .WithOne(customer => customer.Organization);
+            .WithOne(customer => customer.Organization)
+            .HasForeignKey(customer => customer.OrganizationId);
 
+        modelBuilder.Entity<Customer>()
+            .HasIndex(customer => new {customer.OrganizationId, customer.Name})
+            .IsUnique();
 
         modelBuilder.Entity<Customer>()
             .HasMany(customer => customer.Projects)
-            .WithOne(project => project.Customer);
+            .WithOne(project => project.Customer)
+            .HasForeignKey(project => project.CustomerId);
+
+        modelBuilder.Entity<Engagement>()
+            .HasIndex(engagement => new {engagement.CustomerId, engagement.Name})
+            .IsUnique();
 
         modelBuilder.Entity<Engagement>()
             .Property(project => project.State)

--- a/backend/Database/Migrations/20240531132534_ConstraintsToProjectName.Designer.cs
+++ b/backend/Database/Migrations/20240531132534_ConstraintsToProjectName.Designer.cs
@@ -4,6 +4,7 @@ using Database.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20240531132534_ConstraintsToProjectName")]
+    partial class ConstraintsToProjectName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -170,7 +173,7 @@ namespace Database.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("OrganizationId")
                         .IsRequired()
@@ -178,8 +181,7 @@ namespace Database.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("OrganizationId", "Name")
-                        .IsUnique();
+                    b.HasIndex("OrganizationId");
 
                     b.ToTable("Customer");
                 });

--- a/backend/Database/Migrations/20240531132534_ConstraintsToProjectName.cs
+++ b/backend/Database/Migrations/20240531132534_ConstraintsToProjectName.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConstraintsToProjectName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Project_CustomerId",
+                table: "Project");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CompetenceConsultant",
+                table: "CompetenceConsultant");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetenceConsultant_ConsultantId",
+                table: "CompetenceConsultant");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Project",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GraduationYear",
+                table: "Consultant",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CompetenceConsultant",
+                table: "CompetenceConsultant",
+                columns: new[] { "ConsultantId", "CompetencesId" });
+
+            migrationBuilder.InsertData(
+                table: "Competence",
+                columns: new[] { "Id", "Name" },
+                values: new object[] { "development", "Utvikling" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Project_CustomerId_Name",
+                table: "Project",
+                columns: new[] { "CustomerId", "Name" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetenceConsultant_CompetencesId",
+                table: "CompetenceConsultant",
+                column: "CompetencesId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Project_CustomerId_Name",
+                table: "Project");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CompetenceConsultant",
+                table: "CompetenceConsultant");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetenceConsultant_CompetencesId",
+                table: "CompetenceConsultant");
+
+            migrationBuilder.DeleteData(
+                table: "Competence",
+                keyColumn: "Id",
+                keyValue: "development");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Project",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GraduationYear",
+                table: "Consultant",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CompetenceConsultant",
+                table: "CompetenceConsultant",
+                columns: new[] { "CompetencesId", "ConsultantId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Project_CustomerId",
+                table: "Project",
+                column: "CustomerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetenceConsultant_ConsultantId",
+                table: "CompetenceConsultant",
+                column: "ConsultantId");
+        }
+    }
+}

--- a/backend/Database/Migrations/20240603075004_ConstraintsToCustomerName.Designer.cs
+++ b/backend/Database/Migrations/20240603075004_ConstraintsToCustomerName.Designer.cs
@@ -4,6 +4,7 @@ using Database.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20240603075004_ConstraintsToCustomerName")]
+    partial class ConstraintsToCustomerName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Database/Migrations/20240603075004_ConstraintsToCustomerName.cs
+++ b/backend/Database/Migrations/20240603075004_ConstraintsToCustomerName.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConstraintsToCustomerName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Customer_OrganizationId",
+                table: "Customer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Customer",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Customer_OrganizationId_Name",
+                table: "Customer",
+                columns: new[] { "OrganizationId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Customer_OrganizationId_Name",
+                table: "Customer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Customer_OrganizationId",
+                table: "Customer",
+                column: "OrganizationId");
+        }
+    }
+}


### PR DESCRIPTION
Closes #473 #472 

- When writing engagements we now use customer ID which is unique, in stead of customer name (which can be the same across countries, eg. Variant and Variant in norway and sweden)
- Added constraints in the database so that projectName has to be unique for each customer, and customerName has to be unique for each organization