### PR TITLE
Fix: Disable "Opprett" when the combobox is empty

### DIFF
--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -209,7 +209,7 @@ export default function ComboBox({
             </p>
           </div>
         )}
-        isValidNewOption={() => true}
+        isValidNewOption={(inputText: string) => inputText.length > 0}
         isOptionDisabled={(option) => !!option?.disabled}
       />
     );


### PR DESCRIPTION
Disables the "Oppdrett" button when the Combobox is empty. However, now there is no indication that you can create new choices unless you start to write, so maybe the `noOptionsMessage` should be changed to indicate this 