### PR TITLE
Fix bug that neither planned or used counted today

### DIFF
--- a/backend/Core/DomainModels/Consultant.cs
+++ b/backend/Core/DomainModels/Consultant.cs
@@ -57,7 +57,7 @@ public class Consultant
 
     public int GetPlannedVacationDays(DateOnly day)
     {
-        return Vacations.Where(v => v.Date.Year.Equals(day.Year)).Count(v => v.Date > day);
+        return Vacations.Where(v => v.Date.Year.Equals(day.Year)).Count(v => v.Date >= day);
     }
 
     public int GetRemainingVacationDays(DateOnly day)

--- a/frontend/src/components/VacationCalendar.tsx
+++ b/frontend/src/components/VacationCalendar.tsx
@@ -136,6 +136,7 @@ export default function VacationCalendar({
           onChange={handleChange}
           className="custom-calendar"
           mapDays={({ date }) => {
+            //Since the date object is created before the today object, an extra hour is added to a copied version of the date object to ensure that you can edit today
             const dateCopy = new DateObject(date);
             dateCopy.add(1, "h");
 

--- a/frontend/src/components/VacationCalendar.tsx
+++ b/frontend/src/components/VacationCalendar.tsx
@@ -136,6 +136,9 @@ export default function VacationCalendar({
           onChange={handleChange}
           className="custom-calendar"
           mapDays={({ date }) => {
+            const dateCopy = new DateObject(date);
+            dateCopy.add(1, "h");
+
             let isWeekend = [0, 6].includes(date.weekDay.index);
             if (
               vacationDays.vacationDays?.includes(
@@ -147,7 +150,7 @@ export default function VacationCalendar({
                   date.day > 9 ? date.day.toString() : "0" + date.day.toString()
                 }`,
               ) &&
-              date.toDate() <= new Date()
+              dateCopy.toDate() < new Date()
             )
               return {
                 disabled: true,
@@ -172,7 +175,7 @@ export default function VacationCalendar({
                 disabled: true,
                 style: { color: "#B91456", opacity: 0.5 },
               };
-            else if (isWeekend || date.toDate() <= new Date())
+            else if (isWeekend || dateCopy.toDate() < new Date())
               return {
                 disabled: true,
                 style: { color: "#00445B", opacity: 0.5 },


### PR DESCRIPTION
If the "today" date is the same date as a vacation date, it is neither counted towards planned or used. Also changed that today is not disabled. This i am more unsure about so it can be changed, but then getPlannedVacationDays should be changed to not include today, and used vacation days should count it instead