### PR TITLE
Fix/missing check in combobox styling

### DIFF
--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -77,14 +77,20 @@ export default function ComboBox({
     if (!isCreatable || !Array.isArray(props?.children))
       return <components.MenuList {...props} />;
 
-    const menuOptions = props.children.slice(0, props.children.length - 1);
-    const createOption = props.children[props.children.length - 1];
+    const menuOptions = inputValue.length
+      ? props.children.slice(0, props.children.length - 1)
+      : props.children;
+    const createOption = inputValue.length
+      ? props.children[props.children.length - 1]
+      : null;
 
     const menuListProps = { ...props, maxHeight: props.maxHeight - 55 };
 
-    const creatableClassName = `sticky w-full bottom-0 pb-1 bg-white ${
-      menuOptions.length && inputValue.length && "border-t border-black/10 pt-1"
-    }`;
+    const creatableClassName = inputValue.length
+      ? `sticky w-full bottom-0 pb-1 bg-white ${
+          menuOptions.length && "border-t border-black/10 pt-1"
+        }`
+      : "";
 
     return (
       <>

--- a/frontend/src/components/ComboBox.tsx
+++ b/frontend/src/components/ComboBox.tsx
@@ -83,7 +83,7 @@ export default function ComboBox({
     const menuListProps = { ...props, maxHeight: props.maxHeight - 55 };
 
     const creatableClassName = `sticky w-full bottom-0 pb-1 bg-white ${
-      menuOptions.length && "border-t border-black/10 pt-1"
+      menuOptions.length && inputValue.length && "border-t border-black/10 pt-1"
     }`;
 
     return (


### PR DESCRIPTION
When disabling the create button for projects the styling for the creatable option were put on the last element of the list. This ensures that the styling is only plased on the creatable option