### PR TITLE
Automatic added "Not started or quit" to consultants

### DIFF
--- a/backend/Api/StaffingController/StaffingReadModel.cs
+++ b/backend/Api/StaffingController/StaffingReadModel.cs
@@ -86,7 +86,8 @@ public record WeeklyBookingReadModel(
     [property: Required] double TotalSellableTime,
     [property: Required] double TotalHolidayHours,
     [property: Required] double TotalVacationHours,
-    [property: Required] double TotalOverbooking);
+    [property: Required] double TotalOverbooking, 
+    [property: Required] double TotalNotStartedOrQuit);
 
 public record BookingDetails(
     [property: Required] string ProjectName,
@@ -104,5 +105,6 @@ public enum BookingType
     Booking,
     PlannedAbsence,
     Vacation,
-    Available
+    Available,
+    NotStartedOrQuit
 }

--- a/frontend/mockdata/mockData.ts
+++ b/frontend/mockdata/mockData.ts
@@ -17,6 +17,7 @@ const MockWeeklyBookingReadModel: WeeklyBookingReadModel = {
   totalOffered: 0,
   totalVacationHours: 0,
   totalExludableAbsence: 0,
+  totalNotStartedOrQuit: 0,
 };
 
 export const MockConsultants: ConsultantReadModel[] = [

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -38,6 +38,7 @@ export enum BookingType {
   PlannedAbsence = "PlannedAbsence",
   Vacation = "Vacation",
   Available = "Available",
+  NotStartedOrQuit = "NotStartedOrQuit",
 }
 
 export interface ConsultantReadModel {
@@ -273,7 +274,10 @@ export interface WeeklyBookingReadModel {
   totalVacationHours: number;
   /** @format double */
   totalOverbooking: number;
+  /** @format double */
   totalExludableAbsence: number;
+  /** @format double */
+  totalNotStartedOrQuit: number;
 }
 
 export interface WeeklyHours {

--- a/frontend/src/components/Staffing/DetailedBookingRows.tsx
+++ b/frontend/src/components/Staffing/DetailedBookingRows.tsx
@@ -340,7 +340,9 @@ function DetailedBookingCell({
       >
         {isChangingHours &&
           numWeeks <= 12 &&
-          detailedBooking.bookingDetails.type != BookingType.Vacation && (
+          detailedBooking.bookingDetails.type != BookingType.Vacation &&
+          detailedBooking.bookingDetails.projectName !=
+            "Ikke startet eller sluttet" && (
             <button
               tabIndex={-1}
               disabled={hours == 0}
@@ -368,7 +370,11 @@ function DetailedBookingCell({
           step={workHoursPerDay}
           value={hours}
           draggable={true}
-          disabled={detailedBooking.bookingDetails.type == BookingType.Vacation}
+          disabled={
+            detailedBooking.bookingDetails.type == BookingType.Vacation ||
+            detailedBooking.bookingDetails.projectName ==
+              "Ikke startet eller sluttet"
+          }
           onChange={(e) =>
             hourDragValue == undefined && setHours(Number(e.target.value))
           }
@@ -401,7 +407,9 @@ function DetailedBookingCell({
         ></input>
         {isChangingHours &&
           numWeeks <= 12 &&
-          detailedBooking.bookingDetails.type != BookingType.Vacation && (
+          detailedBooking.bookingDetails.type != BookingType.Vacation &&
+          detailedBooking.bookingDetails.projectName !=
+            "Ikke startet eller sluttet" && (
             <button
               tabIndex={-1}
               className={`my-1 p-1 rounded-full hover:bg-primary/10 hidden ${

--- a/frontend/src/components/Staffing/DetailedBookingRows.tsx
+++ b/frontend/src/components/Staffing/DetailedBookingRows.tsx
@@ -341,8 +341,8 @@ function DetailedBookingCell({
         {isChangingHours &&
           numWeeks <= 12 &&
           detailedBooking.bookingDetails.type != BookingType.Vacation &&
-          detailedBooking.bookingDetails.projectName !=
-            "Ikke startet eller sluttet" && (
+          detailedBooking.bookingDetails.type !=
+            BookingType.NotStartedOrQuit && (
             <button
               tabIndex={-1}
               disabled={hours == 0}
@@ -372,8 +372,7 @@ function DetailedBookingCell({
           draggable={true}
           disabled={
             detailedBooking.bookingDetails.type == BookingType.Vacation ||
-            detailedBooking.bookingDetails.projectName ==
-              "Ikke startet eller sluttet"
+            detailedBooking.bookingDetails.type != BookingType.NotStartedOrQuit
           }
           onChange={(e) =>
             hourDragValue == undefined && setHours(Number(e.target.value))
@@ -408,8 +407,8 @@ function DetailedBookingCell({
         {isChangingHours &&
           numWeeks <= 12 &&
           detailedBooking.bookingDetails.type != BookingType.Vacation &&
-          detailedBooking.bookingDetails.projectName !=
-            "Ikke startet eller sluttet" && (
+          detailedBooking.bookingDetails.type !=
+            BookingType.NotStartedOrQuit && (
             <button
               tabIndex={-1}
               className={`my-1 p-1 rounded-full hover:bg-primary/10 hidden ${

--- a/frontend/src/components/Staffing/WeekCell.tsx
+++ b/frontend/src/components/Staffing/WeekCell.tsx
@@ -1,7 +1,14 @@
 import { BookedHoursPerWeek, ConsultantReadModel } from "@/api-types";
 import { HoveredWeek } from "@/components/Staffing/HoveredWeek";
 import InfoPill from "@/components/Staffing/InfoPill";
-import { AlertTriangle, Coffee, FileText, Moon, Sun } from "react-feather";
+import {
+  AlertTriangle,
+  Calendar,
+  Coffee,
+  FileText,
+  Moon,
+  Sun,
+} from "react-feather";
 import { getInfopillVariantByColumnCount } from "@/components/Staffing/helpers/utils";
 import React from "react";
 
@@ -148,14 +155,27 @@ export function WeekCell(props: {
               variant={getInfopillVariantByColumnCount(columnCount)}
             />
           )}
+          {bookedHoursPerWeek.bookingModel.totalNotStartedOrQuit > 0 && (
+            <InfoPill
+              text={bookedHoursPerWeek.bookingModel.totalNotStartedOrQuit.toLocaleString(
+                "nb-No",
+                {
+                  maximumFractionDigits: 1,
+                  minimumFractionDigits: 0,
+                },
+              )}
+              colors="bg-absence/60 text-absence_darker border-absence_darker"
+              icon={<Calendar size="12" />}
+              variant={getInfopillVariantByColumnCount(columnCount)}
+            />
+          )}
         </div>
         <p
           className={`text-right ${
             isListElementVisible ? "normal-medium" : "normal"
           }`}
         >
-          {bookedHoursPerWeek.bookingModel.totalPlannedAbsences > 0 &&
-          checkIfNotStartedOrQuit(consultant, bookedHoursPerWeek, numWorkHours)
+          {checkIfNotStartedOrQuit(consultant, bookedHoursPerWeek, numWorkHours)
             ? "-"
             : bookedHoursPerWeek.bookingModel.totalBillable.toLocaleString(
                 "nb-No",
@@ -171,17 +191,11 @@ function checkIfNotStartedOrQuit(
   bookedHoursPerWeek: BookedHoursPerWeek,
   numWorkHours: number,
 ) {
-  const project = consultant.detailedBooking.find(
-    (b) => b.bookingDetails.projectName == "Ikke startet eller sluttet",
-  );
-  const hours = project?.hours.find(
-    (h) => h.week == bookedHoursPerWeek.sortableWeek,
-  );
-
-  if (!hours?.hours) return false;
+  const notStartedOrQuitHours =
+    bookedHoursPerWeek.bookingModel.totalNotStartedOrQuit;
 
   return (
-    hours?.hours ==
+    notStartedOrQuitHours ==
     numWorkHours - bookedHoursPerWeek.bookingModel.totalHolidayHours
   );
 }

--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -5,7 +5,14 @@ import {
   EngagementState,
 } from "@/api-types";
 import React, { ReactElement } from "react";
-import { Briefcase, Coffee, FileText, Moon, Sun } from "react-feather";
+import {
+  Briefcase,
+  Calendar,
+  Coffee,
+  FileText,
+  Moon,
+  Sun,
+} from "react-feather";
 import { InfoPillVariant } from "@/components/Staffing/InfoPill";
 
 export function getColorByStaffingType(type: BookingType): string {
@@ -20,6 +27,8 @@ export function getColorByStaffingType(type: BookingType): string {
       return "bg-absence";
     case BookingType.Available:
       return "bg-available";
+    case BookingType.NotStartedOrQuit:
+      return "bg-absence/60";
     default:
       return "";
   }
@@ -69,6 +78,8 @@ export function getIconByBookingType(
       return <Moon size={size} className="text-absence_darker" />;
     case BookingType.Available:
       return <Coffee size={size} className="text-available_darker" />;
+    case BookingType.NotStartedOrQuit:
+      return <Calendar size={size} className="text-absence_darker/70" />;
     default:
       return <></>;
   }

--- a/frontend/src/hooks/staffing/useConsultantsFilter.ts
+++ b/frontend/src/hooks/staffing/useConsultantsFilter.ts
@@ -286,6 +286,7 @@ function setWeeklyInvoiceRate(
             numWorkHours -
             booking.bookingModel.totalHolidayHours -
             booking.bookingModel.totalExludableAbsence -
+            booking.bookingModel.totalNotStartedOrQuit -
             booking.bookingModel.totalVacationHours;
 
           totalAvailableWeekHours += consultantAvailableWeekHours;


### PR DESCRIPTION
This PR adds the "Not started or quit" project to every consultant that has a startdate or enddate in the visible weeks. Righty now its added everytime DetailedBookings is created, and its not saved in the database. I've also made "NotStartedOrQuit" it's own BookingType, to more clearly distingquish it from absence, and to not have to check strings for the front end to work. 