### PR TITLE
Add Repository for Staffing

### DIFF
--- a/backend/Api/Common/StorageService.cs
+++ b/backend/Api/Common/StorageService.cs
@@ -100,12 +100,6 @@ public class StorageService
             .OrderBy(consultant => consultant.Name)
             .ToList();
 
-        var staffingPrConsultant = _dbContext.Staffing
-            .Include(s => s.Consultant)
-            .Include(staffing => staffing.Engagement)
-            .ThenInclude(project => project.Customer)
-            .GroupBy(staffing => staffing.Consultant.Id)
-            .ToDictionary(group => group.Key, grouping => grouping.ToList());
 
         var plannedAbsencePrConsultant = _dbContext.PlannedAbsence
             .Include(absence => absence.Absence)
@@ -120,16 +114,12 @@ public class StorageService
 
         var hydratedConsultants = consultantList.Select(consultant =>
         {
-            consultant.Staffings = staffingPrConsultant.TryGetValue(consultant.Id, out var staffing)
-                ? staffing
-                : new List<Staffing>();
-
             consultant.PlannedAbsences =
                 plannedAbsencePrConsultant.TryGetValue(consultant.Id, out var plannedAbsences)
                     ? plannedAbsences
                     : new List<PlannedAbsence>();
 
-            consultant.Vacations = vacationsPrConsultant.TryGetValue(consultant.Id, out var vacations)
+            consultant.Vacations = vacationsPrConsultant.TryGetValue(consultant.Id, out List<Vacation>? vacations)
                 ? vacations
                 : new List<Vacation>();
 

--- a/backend/Api/Common/StorageService.cs
+++ b/backend/Api/Common/StorageService.cs
@@ -139,23 +139,6 @@ public class StorageService
         return hydratedConsultants;
     }
 
-    private Staffing CreateStaffing(StaffingKey staffingKey, double hours)
-    {
-        var consultant = _dbContext.Consultant.Single(c => c.Id == staffingKey.ConsultantId);
-        var project = _dbContext.Project.Single(p => p.Id == staffingKey.EngagementId);
-
-        var staffing = new Staffing
-        {
-            EngagementId = staffingKey.EngagementId,
-            Engagement = project,
-            ConsultantId = staffingKey.ConsultantId,
-            Consultant = consultant,
-            Hours = hours,
-            Week = staffingKey.Week
-        };
-        return staffing;
-    }
-
     private PlannedAbsence CreateAbsence(PlannedAbsenceKey plannedAbsenceKey, double hours)
     {
         var consultant = _dbContext.Consultant.Single(c => c.Id == plannedAbsenceKey.ConsultantId);
@@ -173,23 +156,6 @@ public class StorageService
         return plannedAbsence;
     }
 
-    public void UpdateOrCreateStaffing(StaffingKey staffingKey, double hours, string orgUrlKey)
-    {
-        var staffing = _dbContext.Staffing
-            .FirstOrDefault(s => s.EngagementId.Equals(staffingKey.EngagementId)
-                                 && s.ConsultantId.Equals(staffingKey.ConsultantId)
-                                 && s.Week.Equals(staffingKey.Week));
-
-
-        if (staffing is null)
-            _dbContext.Add(CreateStaffing(staffingKey, hours));
-        else
-            staffing.Hours = hours;
-
-        _dbContext.SaveChanges();
-        ClearConsultantCache(orgUrlKey);
-    }
-
 
     public void UpdateOrCreatePlannedAbsence(PlannedAbsenceKey plannedAbsenceKey, double hours, string orgUrlKey)
     {
@@ -202,55 +168,6 @@ public class StorageService
             _dbContext.Add(CreateAbsence(plannedAbsenceKey, hours));
         else
             plannedAbsence.Hours = hours;
-
-        _dbContext.SaveChanges();
-        ClearConsultantCache(orgUrlKey);
-    }
-
-    public void UpdateOrCreateStaffings(int consultantId, int projectId, List<Week> weeks, double hours,
-        string orgUrlKey)
-    {
-        var consultant = _dbContext.Consultant.Single(c => c.Id == consultantId);
-        var project = _dbContext.Project.Single(p => p.Id == projectId);
-
-        var org = _dbContext.Organization.FirstOrDefault(o => o.UrlKey == orgUrlKey);
-
-        foreach (var week in weeks)
-        {
-            var newHours = hours;
-            if (org != null)
-            {
-                var holidayHours = org.GetTotalHolidayHoursOfWeek(week);
-                var vacations = _dbContext.Vacation.Where(v => v.ConsultantId.Equals(consultantId)).ToList();
-                var vacationHours = vacations.Count(v => week.ContainsDate(v.Date)) * org.HoursPerWorkday;
-                var plannedAbsenceHours = _dbContext.PlannedAbsence
-                    .Where(pa => pa.Week.Equals(week) && pa.ConsultantId.Equals(consultantId))
-                    .Select(pa => pa.Hours).Sum();
-
-                var total = holidayHours + vacationHours + plannedAbsenceHours;
-
-                newHours = hours + total > org.HoursPerWorkday * 5
-                    ? Math.Max(org.HoursPerWorkday * 5 - total, 0)
-                    : hours;
-            }
-
-            var staffing = _dbContext.Staffing
-                .FirstOrDefault(s => s.EngagementId.Equals(projectId)
-                                     && s.ConsultantId.Equals(consultantId)
-                                     && s.Week.Equals(week));
-            if (staffing is null)
-                _dbContext.Add(new Staffing
-                {
-                    EngagementId = projectId,
-                    Engagement = project,
-                    ConsultantId = consultantId,
-                    Consultant = consultant,
-                    Hours = newHours,
-                    Week = week
-                });
-            else
-                staffing.Hours = newHours;
-        }
 
         _dbContext.SaveChanges();
         ClearConsultantCache(orgUrlKey);

--- a/backend/Api/StaffingController/ReadModelFactory.cs
+++ b/backend/Api/StaffingController/ReadModelFactory.cs
@@ -14,12 +14,12 @@ public class ReadModelFactory
         _storageService = storageService;
     }
 
-    public List<StaffingReadModel> GetConsultantReadModelsForWeeks(string orgUrlKey, List<Week> weeks)
+    public List<StaffingReadModel> GetConsultantReadModelsForWeeks(List<Consultant> consultants, List<Week> weeks)
     {
         var firstDayInScope = weeks.First().FirstDayOfWorkWeek();
         var firstWorkDayOutOfScope = weeks.Last().LastWorkDayOfWeek();
 
-        return _storageService.LoadConsultants(orgUrlKey)
+        return consultants
             .Where(c => c.EndDate == null || c.EndDate > firstDayInScope)
             .Where(c => c.StartDate == null || c.StartDate < firstWorkDayOutOfScope)
             .Select(consultant => MapToReadModelList(consultant, weeks))

--- a/backend/Api/StaffingController/StaffingController.cs
+++ b/backend/Api/StaffingController/StaffingController.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Api.Common;
 using Core.Consultants;
 using Core.DomainModels;
@@ -26,8 +25,6 @@ public class StaffingController(ApplicationContext context, IMemoryCache cache, 
         [FromQuery(Name = "WeekSpan")] int numberOfWeeks = 8,
         [FromQuery(Name = "includeOccupied")] bool includeOccupied = true)
     {
-        var watch = Stopwatch.StartNew();
-
         var selectedWeek = selectedYearParam is null || selectedWeekParam is null
             ? Week.FromDateTime(DateTime.Now)
             : new Week((int)selectedYearParam, (int)selectedWeekParam);
@@ -40,9 +37,6 @@ public class StaffingController(ApplicationContext context, IMemoryCache cache, 
 
         var readModels = new ReadModelFactory(service)
             .GetConsultantReadModelsForWeeks(consultants, weekSet);
-
-        watch.Stop();
-        Console.WriteLine($"GET Staffing: {watch.ElapsedMilliseconds}");
 
         return Ok(readModels);
     }

--- a/backend/Api/StaffingController/StaffingController.cs
+++ b/backend/Api/StaffingController/StaffingController.cs
@@ -200,9 +200,16 @@ public class StaffingController(ApplicationContext context, IMemoryCache cache, 
     private async Task<List<Consultant>> AddRelationalDataToConsultant(List<Consultant> consultants,
         CancellationToken ct)
     {
-        foreach (var c in consultants) c.Staffings = await staffingRepository.GetStaffingForConsultant(c.Id, ct);
-
-        return consultants;
+        var consultantStaffings =
+            await staffingRepository.GetStaffingForConsultants(consultants.Select(c => c.Id).ToList(), ct);
+        return consultants.Select(c =>
+        {
+            var hasStaffing = consultantStaffings.TryGetValue(c.Id, out var staffings);
+            if (!hasStaffing || staffings is null)
+                staffings = new List<Staffing>();
+            c.Staffings = staffings;
+            return c;
+        }).ToList();
     }
 
     //TODO: Divide this more neatly into various functions for readability. 

--- a/backend/Core/Staffings/IStaffingRepository.cs
+++ b/backend/Core/Staffings/IStaffingRepository.cs
@@ -1,0 +1,10 @@
+namespace Core.Staffings;
+
+public interface IStaffingRepository
+{
+    public Task<List<Staffing>> GetStaffingForConsultant(int consultantId, CancellationToken ct);
+
+    public Task UpsertStaffing(Staffing staffing, CancellationToken ct);
+
+    public Task UpsertMultipleStaffings(List<Staffing> staffings, CancellationToken ct);
+}

--- a/backend/Core/Staffings/IStaffingRepository.cs
+++ b/backend/Core/Staffings/IStaffingRepository.cs
@@ -2,6 +2,9 @@ namespace Core.Staffings;
 
 public interface IStaffingRepository
 {
+    public Task<Dictionary<int, List<Staffing>>> GetStaffingForConsultants(List<int> consultantIds,
+        CancellationToken ct);
+
     public Task<List<Staffing>> GetStaffingForConsultant(int consultantId, CancellationToken ct);
 
     public Task UpsertStaffing(Staffing staffing, CancellationToken ct);

--- a/backend/Infrastructure/Repositories/RepositoryExtensions.cs
+++ b/backend/Infrastructure/Repositories/RepositoryExtensions.cs
@@ -1,9 +1,11 @@
 using Core.Consultants;
 using Core.Engagements;
 using Core.Organizations;
+using Core.Staffings;
 using Infrastructure.Repositories.Consultants;
 using Infrastructure.Repositories.Engagement;
 using Infrastructure.Repositories.Organization;
+using Infrastructure.Repositories.Staffings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,6 +20,9 @@ public static class RepositoryExtensions
 
         builder.Services.AddScoped<IEngagementRepository, EngagementDbRepository>();
         builder.Services.AddScoped<IDepartmentRepository, DepartmentDbRepository>();
+
+        builder.Services.AddScoped<IStaffingRepository, StaffingDbRepository>();
+        builder.Services.Decorate<IStaffingRepository, StaffingCacheRepository>();
 
         builder.Services.AddScoped<IConsultantRepository, ConsultantDbRepository>();
     }

--- a/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
@@ -1,0 +1,42 @@
+using Core.Staffings;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Infrastructure.Repositories.Staffings;
+
+public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemoryCache cache) : IStaffingRepository
+{
+    public async Task<List<Staffing>> GetStaffingForConsultant(int consultantId, CancellationToken ct)
+    {
+        if (cache.TryGetValue<List<Staffing>>(StaffingCacheKey(consultantId), out var staffingList))
+            if (staffingList is not null)
+                return staffingList;
+
+        staffingList = await sourceRepository.GetStaffingForConsultant(consultantId, ct);
+        cache.Set(StaffingCacheKey(consultantId), staffingList);
+        return staffingList;
+    }
+
+    public async Task UpsertStaffing(Staffing staffing, CancellationToken ct)
+    {
+        await sourceRepository.UpsertStaffing(staffing, ct);
+        ClearStaffingCache(staffing.ConsultantId);
+    }
+
+    public async Task UpsertMultipleStaffings(List<Staffing> staffings, CancellationToken ct)
+    {
+        await sourceRepository.UpsertMultipleStaffings(staffings, ct);
+
+        var consultantIds = staffings.Select(staffing => staffing.ConsultantId).Distinct();
+        foreach (var consultantId in consultantIds) ClearStaffingCache(consultantId);
+    }
+
+    private void ClearStaffingCache(int consultantId)
+    {
+        cache.Remove(StaffingCacheKey(consultantId));
+    }
+
+    private static string StaffingCacheKey(int consultantId)
+    {
+        return $"StaffingCacheRepository/{consultantId}";
+    }
+}

--- a/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
@@ -5,14 +5,33 @@ namespace Infrastructure.Repositories.Staffings;
 
 public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemoryCache cache) : IStaffingRepository
 {
+    public async Task<Dictionary<int, List<Staffing>>> GetStaffingForConsultants(List<int> consultantIds,
+        CancellationToken ct)
+    {
+        var nonCachedIds = new List<int>();
+        var result = new Dictionary<int, List<Staffing>>();
+
+        foreach (var consultantId in consultantIds)
+        {
+            var staffingList = GetStaffingsFromCache(consultantId);
+            if (staffingList is null)
+                nonCachedIds.Add(consultantId);
+            else
+                result.Add(consultantId, staffingList);
+        }
+
+        var queriedStaffingLists = await sourceRepository.GetStaffingForConsultants(nonCachedIds, ct);
+
+        queriedStaffingLists.ToList()
+            .ForEach(consultantStaffing => result.Add(consultantStaffing.Key, consultantStaffing.Value));
+
+        return result;
+    }
+
     public async Task<List<Staffing>> GetStaffingForConsultant(int consultantId, CancellationToken ct)
     {
-        if (cache.TryGetValue<List<Staffing>>(StaffingCacheKey(consultantId), out var staffingList))
-            if (staffingList is not null)
-            {
-                Console.Out.WriteLineAsync($"Cache hit, ID: {consultantId}");
-                return staffingList;
-            }
+        var staffingList = GetStaffingsFromCache(consultantId);
+        if (staffingList is not null) return staffingList;
 
         staffingList = await sourceRepository.GetStaffingForConsultant(consultantId, ct);
         cache.Set(StaffingCacheKey(consultantId), staffingList);
@@ -31,6 +50,18 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
 
         var consultantIds = staffings.Select(staffing => staffing.ConsultantId).Distinct();
         foreach (var consultantId in consultantIds) ClearStaffingCache(consultantId);
+    }
+
+    private List<Staffing>? GetStaffingsFromCache(int consultantId)
+    {
+        if (cache.TryGetValue<List<Staffing>>(StaffingCacheKey(consultantId), out var staffingList))
+            if (staffingList is not null)
+            {
+                Console.Out.WriteLineAsync($"Cache hit, ID: {consultantId}");
+                return staffingList;
+            }
+
+        return null;
     }
 
     private void ClearStaffingCache(int consultantId)

--- a/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
@@ -9,7 +9,10 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
     {
         if (cache.TryGetValue<List<Staffing>>(StaffingCacheKey(consultantId), out var staffingList))
             if (staffingList is not null)
+            {
+                Console.Out.WriteLineAsync($"Cache hit, ID: {consultantId}");
                 return staffingList;
+            }
 
         staffingList = await sourceRepository.GetStaffingForConsultant(consultantId, ct);
         cache.Set(StaffingCacheKey(consultantId), staffingList);

--- a/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
@@ -21,9 +21,11 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
         }
 
         var queriedStaffingLists = await sourceRepository.GetStaffingForConsultants(nonCachedIds, ct);
-
-        queriedStaffingLists.ToList()
-            .ForEach(consultantStaffing => result.Add(consultantStaffing.Key, consultantStaffing.Value));
+        foreach (var (cId, staffings) in queriedStaffingLists)
+        {
+            result.Add(cId, staffings);
+            cache.Set(StaffingCacheKey(cId), staffings);
+        }
 
         return result;
     }

--- a/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
@@ -6,6 +6,22 @@ namespace Infrastructure.Repositories.Staffings;
 
 public class StaffingDbRepository(ApplicationContext context) : IStaffingRepository
 {
+    public async Task<Dictionary<int, List<Staffing>>> GetStaffingForConsultants(List<int> consultantIds,
+        CancellationToken ct)
+    {
+        var ids = consultantIds.ToArray();
+
+        Console.Out.WriteLine($"Quering {consultantIds.Count} from DB");
+
+        return await context.Staffing
+            .Where(s => ids.Contains(s.ConsultantId))
+            .Include(s => s.Consultant)
+            .Include(staffing => staffing.Engagement)
+            .ThenInclude(project => project.Customer)
+            .GroupBy(staffing => staffing.Consultant.Id)
+            .ToDictionaryAsync(group => group.Key, grouping => grouping.ToList(), ct);
+    }
+
     public async Task<List<Staffing>> GetStaffingForConsultant(int consultantId, CancellationToken ct)
     {
         return await context.Staffing

--- a/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
@@ -11,8 +11,6 @@ public class StaffingDbRepository(ApplicationContext context) : IStaffingReposit
     {
         var ids = consultantIds.ToArray();
 
-        Console.Out.WriteLine($"Quering {consultantIds.Count} from DB");
-
         return await context.Staffing
             .Where(s => ids.Contains(s.ConsultantId))
             .Include(s => s.Consultant)

--- a/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
@@ -18,16 +18,15 @@ public class StaffingDbRepository(ApplicationContext context) : IStaffingReposit
 
     public async Task UpsertMultipleStaffings(List<Staffing> staffings, CancellationToken ct)
     {
-        var upsertJobs = staffings.Select<Staffing, Task>(async staffing => await UpsertStaffing(staffing, ct));
-
-        await Task.WhenAll(upsertJobs);
+        foreach (var staffing in staffings) await UpsertStaffing(staffing, ct);
     }
 
     public async Task UpsertStaffing(Staffing staffing, CancellationToken ct)
     {
-        var existingStaffing =
-            await context.Staffing.FindAsync(
-                new StaffingKey(staffing.EngagementId, staffing.ConsultantId, staffing.Week), ct);
+        var existingStaffing = context.Staffing
+            .FirstOrDefault(s => s.EngagementId.Equals(staffing.EngagementId)
+                                 && s.ConsultantId.Equals(staffing.ConsultantId)
+                                 && s.Week.Equals(staffing.Week));
 
         if (existingStaffing is null)
         {

--- a/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingDbRepository.cs
@@ -1,0 +1,41 @@
+using Core.Staffings;
+using Infrastructure.DatabaseContext;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories.Staffings;
+
+public class StaffingDbRepository(ApplicationContext context) : IStaffingRepository
+{
+    public async Task<List<Staffing>> GetStaffingForConsultant(int consultantId, CancellationToken ct)
+    {
+        return await context.Staffing
+            .Where(staffing => staffing.ConsultantId == consultantId)
+            .Include(s => s.Engagement)
+            .ThenInclude(p => p.Customer)
+            .ToListAsync(ct);
+    }
+
+
+    public async Task UpsertMultipleStaffings(List<Staffing> staffings, CancellationToken ct)
+    {
+        var upsertJobs = staffings.Select<Staffing, Task>(async staffing => await UpsertStaffing(staffing, ct));
+
+        await Task.WhenAll(upsertJobs);
+    }
+
+    public async Task UpsertStaffing(Staffing staffing, CancellationToken ct)
+    {
+        var existingStaffing =
+            await context.Staffing.FindAsync(
+                new StaffingKey(staffing.EngagementId, staffing.ConsultantId, staffing.Week), ct);
+
+        if (existingStaffing is null)
+        {
+            await context.Staffing.AddAsync(staffing, ct);
+            return;
+        }
+
+        existingStaffing.Hours = staffing.Hours;
+        await context.SaveChangesAsync(ct);
+    }
+}


### PR DESCRIPTION
Adds a Staffing repository following the pattern established with ConsultantRepository etc. 

Due to heavy queries, this one also gets a layer of caching. Currently this is optimistic based on that current queries are always based on a Consultant, i.e. "All staffing for this consultant id". 

Unlike previous refactors, this one also changes the logic a good bit: 
 - Instead of one huge cache-entry for all the staffing, this now caches _per consultant_. More on this later. 
 - The responsibility to join the data from the repo is now in the Controller layer. This **should** be in an Application layer, but I want to tackle this one thing at a time. 

## More on caching:
Since it's just one StaffingCacheRepository now, this can have more granular caching, with keys pr consultant. 
This is to support the by far most common use-case: Getting Staffing for one or more consultants. Other use-cases in the future like Staffing pr project would just be forwarded to the DB-repository class. 

This means that we don't need to re-fetch everything when staffing changes. More on this in performance. 

## Will this hurt performance?
Yes and no. 
The initial call, which first populates the DB is slower:
ca. 7-800ms before, vs 900-1.000 ms now

Loading with no changes is about the same:
10-80ms before, vs 20-40 ms now

With some changes to staffing, this is faster though: 
ca. 3-400ms before, vs ca. 150ms now 

## Todos
To avoid scope-creep, here are some TODOs left. These are mainly there due to a lacking Application-layer, which we should add soon. 
