### PR TITLE
580 add number of hours to each month

### DIFF
--- a/frontend/src/components/Forecast/BusinessHoursPerMonth.ts
+++ b/frontend/src/components/Forecast/BusinessHoursPerMonth.ts
@@ -32,9 +32,6 @@ function isPublicHoliday(day: Date, publicHolidayDays: string[]) {
   }`;
 
   const isHoliday = publicHolidayDays.includes(dayString);
-
-  console.log("dayString", dayString, day);
-
   return isHoliday;
 }
 

--- a/frontend/src/components/Forecast/BusinessHoursPerMonth.ts
+++ b/frontend/src/components/Forecast/BusinessHoursPerMonth.ts
@@ -1,0 +1,41 @@
+function getBusinessHoursPerMonth(
+  month: number,
+  year: number,
+  numWorkHours: number,
+  publicHolidayDays: string[],
+) {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const hoursInDay = numWorkHours / 5;
+  var businessDaysCount = 0;
+  var curDate = firstDay;
+  while (curDate <= lastDay) {
+    var dayOfWeek = curDate.getDay();
+    if (!(dayOfWeek == 6 || dayOfWeek == 0)) {
+      if (!isPublicHoliday(curDate, publicHolidayDays)) {
+        businessDaysCount++;
+      }
+    }
+    curDate.setDate(curDate.getDate() + 1);
+  }
+  return businessDaysCount * hoursInDay;
+}
+
+function isPublicHoliday(day: Date, publicHolidayDays: string[]) {
+  const month = day.getMonth();
+  const dayString = `${day.getFullYear().toString()}-${
+    month > 8 ? (month + 1).toString() : "0" + (month + 1).toString()
+  }-${
+    day.getDate() > 9
+      ? day.getDate().toString()
+      : "0" + day.getDate().toString()
+  }`;
+
+  const isHoliday = publicHolidayDays.includes(dayString);
+
+  console.log("dayString", dayString, day);
+
+  return isHoliday;
+}
+
+export { getBusinessHoursPerMonth };

--- a/frontend/src/components/Forecast/BusinessHoursPerMonth.ts
+++ b/frontend/src/components/Forecast/BusinessHoursPerMonth.ts
@@ -8,15 +8,15 @@ function getBusinessHoursPerMonth(
   const lastDay = new Date(year, month + 1, 0);
   const hoursInDay = numWorkHours / 5;
   var businessDaysCount = 0;
-  var curDate = firstDay;
-  while (curDate <= lastDay) {
-    var dayOfWeek = curDate.getDay();
+  var currentDate = firstDay;
+  while (currentDate <= lastDay) {
+    var dayOfWeek = currentDate.getDay();
     if (!(dayOfWeek == 6 || dayOfWeek == 0)) {
-      if (!isPublicHoliday(curDate, publicHolidayDays)) {
+      if (!isPublicHoliday(currentDate, publicHolidayDays)) {
         businessDaysCount++;
       }
     }
-    curDate.setDate(curDate.getDate() + 1);
+    currentDate.setDate(currentDate.getDate() + 1);
   }
   return businessDaysCount * hoursInDay;
 }

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -11,6 +11,7 @@ import { MockConsultantsForForecast } from "../../../mockdata/mockData";
 import { fetchPublicHolidays } from "@/hooks/fetchPublicHolidays";
 import { usePathname } from "next/navigation";
 import { getBusinessHoursPerMonth } from "./BusinessHoursPerMonth";
+import getNextMonthNamesWithYear from "./NextMonths";
 
 const months = [
   "Januar",
@@ -41,11 +42,18 @@ const monthsShort = [
   "Des",
 ];
 
+const monthsWithYears = getNextMonthNamesWithYear(12);
+
 function mapMonthToNumber(month: string) {
   return monthsShort.indexOf(month);
 }
+
+function mapNumberToMonthShortName(month: number) {
+  return monthsShort[month];
+}
 function isCurrentMonth(month: number) {
-  return month === 0;
+  const today = new Date();
+  return today.getMonth() === month;
 }
 export default function ForecastTable() {
   const {
@@ -88,10 +96,13 @@ export default function ForecastTable() {
               </p>
             </div>
           </th>
-          {monthsShort.map((month, index) => (
-            <th key={month} className=" px-2 py-1 pt-3 ">
+          {monthsWithYears.map((month) => (
+            <th
+              key={"" + month.month + month.year}
+              className=" px-2 py-1 pt-3 "
+            >
               <div className="flex flex-col gap-1">
-                {isCurrentMonth(mapMonthToNumber(month)) ? (
+                {isCurrentMonth(month.month) ? (
                   <div className="flex flex-row gap-2 items-center justify-end">
                     {/* {booking.bookingModel.totalHolidayHours > 0 && (
                       <InfoPill
@@ -109,7 +120,9 @@ export default function ForecastTable() {
                     )} */}
                     <div className="h-2 w-2 rounded-full bg-primary" />
 
-                    <p className="normal-medium text-right">{month}</p>
+                    <p className="normal-medium text-right">
+                      {mapNumberToMonthShortName(month.month)}
+                    </p>
                   </div>
                 ) : (
                   <div
@@ -133,20 +146,22 @@ export default function ForecastTable() {
                         variant={weekSpan < 24 ? "wide" : "medium"}
                       />
                     )} */}
-                    <p className="normal text-right">{month}</p>
+                    <p className="normal text-right">
+                      {mapNumberToMonthShortName(month.month)}
+                    </p>
                   </div>
                 )}
                 <p className="flex justify-end xsmall">
                   {publicHolidays.length > 0
                     ? "" +
                       getBusinessHoursPerMonth(
-                        index,
-                        year,
+                        month.month,
+                        month.year,
                         numWorkHours,
                         publicHolidays,
                       ) +
                       "t"
-                    : " "}
+                    : "-"}
                 </p>
               </div>
             </th>

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -66,7 +66,7 @@ export default function ForecastTable() {
   const [publicHolidays, setPublicHolidays] = useState<string[]>([]);
   const organisationName = usePathname().split("/")[1];
   const { weekSpan } = useContext(FilteredContext).activeFilters;
-  const year = 2025;
+
   useEffect(() => {
     if (organisationName) {
       fetchPublicHolidays(organisationName).then((res) => {

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -51,9 +51,9 @@ function mapMonthToNumber(month: string) {
 function mapNumberToMonthShortName(month: number) {
   return monthsShort[month];
 }
-function isCurrentMonth(month: number) {
+function isCurrentMonth(month: number, year: number) {
   const today = new Date();
-  return today.getMonth() === month;
+  return today.getMonth() === month && today.getFullYear() === year;
 }
 export default function ForecastTable() {
   const {
@@ -102,7 +102,7 @@ export default function ForecastTable() {
               className=" px-2 py-1 pt-3 "
             >
               <div className="flex flex-col gap-1">
-                {isCurrentMonth(month.month) ? (
+                {isCurrentMonth(month.month, month.year) ? (
                   <div className="flex flex-row gap-2 items-center justify-end">
                     {/* {booking.bookingModel.totalHolidayHours > 0 && (
                       <InfoPill
@@ -161,7 +161,7 @@ export default function ForecastTable() {
                         publicHolidays,
                       ) +
                       "t"
-                    : "-"}
+                    : "\u00A0"}
                 </p>
               </div>
             </th>

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -146,7 +146,7 @@ export default function ForecastTable() {
                         publicHolidays,
                       ) +
                       "t"
-                    : null}
+                    : " "}
                 </p>
               </div>
             </th>

--- a/frontend/src/components/Forecast/NextMonths.ts
+++ b/frontend/src/components/Forecast/NextMonths.ts
@@ -1,0 +1,19 @@
+import { Month } from "@/types";
+
+export default function getNextMonthNamesWithYear(
+  numberOfMonths: number,
+): Month[] {
+  var now = new Date();
+  var month = now.getMonth();
+  var year = now.getFullYear();
+
+  var res = [];
+  for (var i = 0; i < numberOfMonths; ++i) {
+    res.push({ month: month, year: year });
+    if (++month === 12) {
+      month = 0;
+      ++year;
+    }
+  }
+  return res;
+}

--- a/frontend/src/components/Staffing/WeekTableHead.tsx
+++ b/frontend/src/components/Staffing/WeekTableHead.tsx
@@ -45,7 +45,7 @@ export function WeekSpanTableHead({
     }
 
     var publicHolidayHours = 0;
-    console.log("\n \n \n \n, public holidays \n \n \n", publicHolidays);
+
     daySpan.forEach((day) => {
       if (
         publicHolidays.length > 0 &&

--- a/frontend/src/components/Staffing/WeekTableHead.tsx
+++ b/frontend/src/components/Staffing/WeekTableHead.tsx
@@ -45,7 +45,7 @@ export function WeekSpanTableHead({
     }
 
     var publicHolidayHours = 0;
-
+    console.log("\n \n \n \n, public holidays \n \n \n", publicHolidays);
     daySpan.forEach((day) => {
       if (
         publicHolidays.length > 0 &&

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,6 +27,10 @@ export interface updateBookingHoursBody {
   endWeek?: number;
 }
 
+export interface Month {
+  month: number;
+  year: number;
+}
 export interface BookedHoursPerMonth {
   month: number;
   year: number;


### PR DESCRIPTION
The number of hours of each month is added below the month name of each column in the prognose table. To do this I created a function that only counts businessdays, excluding public holidays. Public holidays is gotten from the backend. 
<img width="908" alt="Skjermbilde 2025-01-14 kl  09 17 13" src="https://github.com/user-attachments/assets/0fe663d1-4a20-4a24-9634-6f6452bc6651" />
