### PR TITLE
#592 - Refactoring common types and helper methods out of Staffing-related classes

### DIFF
--- a/backend/Api/Common/Types/BookingDetails.cs
+++ b/backend/Api/Common/Types/BookingDetails.cs
@@ -1,0 +1,10 @@
+namespace Api.Common.Types;
+
+public record BookingDetails(
+	string ProjectName,
+	BookingType Type,
+	string CustomerName,
+	int ProjectId,
+	bool ExcludeFromBilling = false,
+	bool IsBillable = false,
+	DateTime? EndDateAgreement = null);

--- a/backend/Api/Common/Types/BookingType.cs
+++ b/backend/Api/Common/Types/BookingType.cs
@@ -1,0 +1,11 @@
+namespace Api.Common.Types;
+
+public enum BookingType
+{
+	Offer,
+	Booking,
+	PlannedAbsence,
+	Vacation,
+	Available,
+	NotStartedOrQuit
+}

--- a/backend/Api/Common/Types/CompetenceReadModel.cs
+++ b/backend/Api/Common/Types/CompetenceReadModel.cs
@@ -1,0 +1,10 @@
+using Core.Consultants;
+
+namespace Api.Common.Types;
+
+public record CompetenceReadModel(string Id, string Name)
+{
+	public CompetenceReadModel(Competence competence) : this(competence.Id, competence.Name)
+	{
+	}
+}

--- a/backend/Api/Common/Types/UpdateDepartmentReadModel.cs
+++ b/backend/Api/Common/Types/UpdateDepartmentReadModel.cs
@@ -1,0 +1,3 @@
+namespace Api.Common.Types;
+
+public record UpdateDepartmentReadModel(string Id, string Name);

--- a/backend/Api/Helpers/DictionaryHelper.cs
+++ b/backend/Api/Helpers/DictionaryHelper.cs
@@ -1,0 +1,14 @@
+namespace Api.Helpers;
+
+public static class DictionaryHelper
+{
+	public static List<T> GetFromDictOrDefault<T>(int key, Dictionary<int, List<T>> dict)
+	{
+		if (dict.TryGetValue(key, out var value) && value is not null)
+		{
+			return value;
+		}
+
+		return [];
+	}
+}

--- a/backend/Api/Helpers/NumericsHelper.cs
+++ b/backend/Api/Helpers/NumericsHelper.cs
@@ -1,0 +1,11 @@
+namespace Api.Helpers;
+
+public static class NumericsHelper
+{
+	private const double Epsilon = 0.00001;
+
+	public static bool DoubleEquals(double a, double b)
+	{
+		return Math.Abs(a - b) < Epsilon;
+	}
+}

--- a/backend/Api/StaffingController/ReadModelFactory.cs
+++ b/backend/Api/StaffingController/ReadModelFactory.cs
@@ -1,4 +1,6 @@
 using Api.Common;
+using Api.Common.Types;
+using Api.Helpers;
 using Core.Consultants;
 using Core.Engagements;
 using Core.Weeks;
@@ -7,12 +9,6 @@ namespace Api.StaffingController;
 
 public class ReadModelFactory(StorageService storageService)
 {
-    private static bool DoubleEquals(double a, double b)
-    {
-        const double epsilon = 0.00001;
-        return Math.Abs(a - b) < epsilon;
-    }
-
     public static List<StaffingReadModel> GetConsultantReadModelsForWeeks(List<Consultant> consultants,
         List<Week> weeks)
     {
@@ -73,7 +69,7 @@ public class ReadModelFactory(StorageService storageService)
         ).ToList();
 
         //checks if the consultant has 0 available hours each week
-        var isOccupied = bookingSummary.All(b => DoubleEquals(b.BookingModel.TotalSellableTime, 0));
+        var isOccupied = bookingSummary.All(b => NumericsHelper.DoubleEquals(b.BookingModel.TotalSellableTime, 0));
 
         return new StaffingReadModel(
             consultant,

--- a/backend/Api/StaffingController/StaffingController.cs
+++ b/backend/Api/StaffingController/StaffingController.cs
@@ -1,4 +1,6 @@
 using Api.Common;
+using Api.Common.Types;
+using Api.Helpers;
 using Core.Consultants;
 using Core.PlannedAbsences;
 using Core.Staffings;
@@ -216,21 +218,12 @@ public class StaffingController(
 
         return consultants.Select(c =>
         {
-            c.Staffings = GetFromDictOrDefault(c.Id, consultantStaffings);
-            c.PlannedAbsences = GetFromDictOrDefault(c.Id, consultantAbsences);
+            c.Staffings = DictionaryHelper.GetFromDictOrDefault(c.Id, consultantStaffings);
+            c.PlannedAbsences = DictionaryHelper.GetFromDictOrDefault(c.Id, consultantAbsences);
 
             return c;
         }).ToList();
     }
-
-    private static List<T> GetFromDictOrDefault<T>(int key, Dictionary<int, List<T>> dict)
-    {
-        var hasValue = dict.TryGetValue(key, out var value);
-        if (hasValue && value is not null) return value;
-
-        return [];
-    }
-
 
     //TODO: Divide this more neatly into various functions for readability. 
     // This is skipped for now to avoid massive scope-creep. Comments are added for a temporary readability-buff

--- a/backend/Api/StaffingController/StaffingReadModel.cs
+++ b/backend/Api/StaffingController/StaffingReadModel.cs
@@ -1,3 +1,4 @@
+using Api.Common.Types;
 using Core.Consultants;
 using Core.Weeks;
 
@@ -31,23 +32,6 @@ public record StaffingReadModel(
             bookings,
             detailedBookings,
             IsOccupied
-        )
-    {
-    }
-}
-
-public record UpdateDepartmentReadModel(
-    string Id,
-    string Name);
-
-public record CompetenceReadModel(
-    string Id,
-    string Name)
-{
-    public CompetenceReadModel(Competence competence)
-        : this(
-            competence.Id,
-            competence.Name
         )
     {
     }
@@ -91,23 +75,4 @@ public record WeeklyBookingReadModel(
     double TotalOverbooking,
     double TotalNotStartedOrQuit);
 
-public record BookingDetails(
-    string ProjectName,
-    BookingType Type,
-    string CustomerName,
-    int ProjectId,
-    bool ExcludeFromBilling = false,
-    bool IsBillable = false,
-    DateTime? EndDateAgreement = null);
-
 public record WeeklyHours(int Week, double Hours);
-
-public enum BookingType
-{
-    Offer,
-    Booking,
-    PlannedAbsence,
-    Vacation,
-    Available,
-    NotStartedOrQuit
-}


### PR DESCRIPTION
As a preperation for constructing forecasts.

Types have been refactored from `StaffingReadModel.cs`. Helper methods have been refactored from `ReadModelFactory.cs` and `StaffingController.cs`.