### PR TITLE
#593 Creating ForecastReadModel and associated models

### DIFF
--- a/backend/Api/Common/Types/BookingReadModel.cs
+++ b/backend/Api/Common/Types/BookingReadModel.cs
@@ -1,0 +1,12 @@
+namespace Api.Common.Types;
+
+public record BookingReadModel(
+	double TotalBillable,
+	double TotalOffered,
+	double TotalPlannedAbsences,
+	double TotalExcludableAbsence,
+	double TotalSellableTime,
+	double TotalHolidayHours,
+	double TotalVacationHours,
+	double TotalOverbooking,
+	double TotalNotStartedOrQuit);

--- a/backend/Api/Forecasts/ForecastReadModel.cs
+++ b/backend/Api/Forecasts/ForecastReadModel.cs
@@ -1,22 +1,14 @@
 using Api.Common.Types;
-using Core.Consultants;
+using Api.Consultants;
 
 namespace Api.Forecasts;
 
 public record ForecastReadModel(
-	int Id,
-	string Name,
-	DateOnly? StartDate,
-	DateOnly? EndDate,
-	List<CompetenceReadModel> Competences,
-	UpdateDepartmentReadModel Department,
-	int YearsOfExperience,
-	int GraduationYear,
-	Degree Degree,
+	SingleConsultantReadModel Consultant,
 	List<BookedHoursInMonth> Bookings,
 	List<DetailedBookingForMonth> DetailedBookings,
 	List<ForecastForMonth> Forecasts,
-	bool IsOccupied);
+	bool ConsultantIsOccupied);
 
 public record BookedHoursInMonth(DateOnly Month, BookingReadModel BookingModel);
 

--- a/backend/Api/Forecasts/ForecastReadModel.cs
+++ b/backend/Api/Forecasts/ForecastReadModel.cs
@@ -16,4 +16,4 @@ public record DetailedBookingForMonth(BookingDetails BookingDetails, List<Monthl
 
 public record struct MonthlyHours(DateOnly Month, double Hours);
 
-public record ForecastForMonth(DateOnly Month, double? CalculatedPercentage, int? DisplayedPercentage);
+public record ForecastForMonth(DateOnly Month, double CalculatedPercentage, int DisplayedPercentage);

--- a/backend/Api/Forecasts/ForecastReadModel.cs
+++ b/backend/Api/Forecasts/ForecastReadModel.cs
@@ -1,0 +1,38 @@
+using Api.Common.Types;
+using Core.Consultants;
+
+namespace Api.Forecasts;
+
+public record ForecastReadModel(
+	int Id,
+	string Name,
+	DateOnly? StartDate,
+	DateOnly? EndDate,
+	List<CompetenceReadModel> Competences,
+	UpdateDepartmentReadModel Department,
+	int YearsOfExperience,
+	int GraduationYear,
+	Degree Degree,
+	List<BookedHoursInMonth> Bookings,
+	List<DetailedBookingForMonth> DetailedBookings,
+	List<ForecastForMonth> Forecasts,
+	bool IsOccupied);
+
+public record BookedHoursInMonth(DateOnly Month, MonthlyBookingReadModel BookingModel);
+
+public record MonthlyBookingReadModel(
+	double TotalBillable,
+	double TotalOffered,
+	double TotalPlannedAbsences,
+	double TotalExcludableAbsence,
+	double TotalSellableTime,
+	double TotalHolidayHours,
+	double TotalVacationHours,
+	double TotalOverbooking,
+	double TotalNotStartedOrQuit);
+
+public record DetailedBookingForMonth(BookingDetails BookingDetails, List<MonthlyHours> Hours);
+
+public record struct MonthlyHours(DateOnly Month, double Hours);
+
+public record ForecastForMonth(DateOnly Month, double? CalculatedPercentage, int? DisplayedPercentage);

--- a/backend/Api/Forecasts/ForecastReadModel.cs
+++ b/backend/Api/Forecasts/ForecastReadModel.cs
@@ -18,18 +18,7 @@ public record ForecastReadModel(
 	List<ForecastForMonth> Forecasts,
 	bool IsOccupied);
 
-public record BookedHoursInMonth(DateOnly Month, MonthlyBookingReadModel BookingModel);
-
-public record MonthlyBookingReadModel(
-	double TotalBillable,
-	double TotalOffered,
-	double TotalPlannedAbsences,
-	double TotalExcludableAbsence,
-	double TotalSellableTime,
-	double TotalHolidayHours,
-	double TotalVacationHours,
-	double TotalOverbooking,
-	double TotalNotStartedOrQuit);
+public record BookedHoursInMonth(DateOnly Month, BookingReadModel BookingModel);
 
 public record DetailedBookingForMonth(BookingDetails BookingDetails, List<MonthlyHours> Hours);
 

--- a/backend/Api/Forecasts/ForecastReadModel.cs
+++ b/backend/Api/Forecasts/ForecastReadModel.cs
@@ -8,7 +8,7 @@ public record ForecastReadModel(
 	List<BookedHoursInMonth> Bookings,
 	List<DetailedBookingForMonth> DetailedBookings,
 	List<ForecastForMonth> Forecasts,
-	bool ConsultantIsOccupied);
+	bool ConsultantIsAvailable);
 
 public record BookedHoursInMonth(DateOnly Month, BookingReadModel BookingModel);
 

--- a/backend/Api/StaffingController/ReadModelFactory.cs
+++ b/backend/Api/StaffingController/ReadModelFactory.cs
@@ -297,7 +297,7 @@ public class ReadModelFactory(StorageService storageService)
             week.WeekNumber,
             week.ToSortableInt(),
             GetDatesForWeek(week),
-            new WeeklyBookingReadModel(totalBillable, totalOffered, totalAbsence, totalExcludableAbsence,
+            new BookingReadModel(totalBillable, totalOffered, totalAbsence, totalExcludableAbsence,
                 totalSellableTime,
                 totalHolidayHours, totalVacations,
                 totalOverbooked, totalNotStartedOrQuit)

--- a/backend/Api/StaffingController/StaffingReadModel.cs
+++ b/backend/Api/StaffingController/StaffingReadModel.cs
@@ -42,7 +42,7 @@ public record BookedHoursPerWeek(
     int WeekNumber,
     int SortableWeek,
     string DateString,
-    WeeklyBookingReadModel BookingModel);
+    BookingReadModel BookingModel);
 
 public record DetailedBooking(
     BookingDetails BookingDetails,
@@ -63,16 +63,5 @@ public record DetailedBooking(
             .Sum();
     }
 }
-
-public record WeeklyBookingReadModel(
-    double TotalBillable,
-    double TotalOffered,
-    double TotalPlannedAbsences,
-    double TotalExcludableAbsence,
-    double TotalSellableTime,
-    double TotalHolidayHours,
-    double TotalVacationHours,
-    double TotalOverbooking,
-    double TotalNotStartedOrQuit);
 
 public record WeeklyHours(int Week, double Hours);

--- a/frontend/mockdata/mockData.ts
+++ b/frontend/mockdata/mockData.ts
@@ -8,11 +8,11 @@ import {
   DetailedBooking,
   EngagementPerCustomerReadModel,
   OrganisationReadModel,
-  WeeklyBookingReadModel,
+  BookingReadModel,
 } from "@/api-types";
 import { Forecast } from "@/types";
 
-const MockWeeklyBookingReadModel: WeeklyBookingReadModel = {
+const MockWeeklyBookingReadModel: BookingReadModel = {
   totalHolidayHours: 0,
   totalOverbooking: 0,
   totalPlannedAbsences: 0,

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -298,3 +298,73 @@ export interface CustomersWithProjectsReadModel {
   activeEngagements: EngagementReadModel[];
   inactiveEngagements: EngagementReadModel[];
 }
+
+export interface ForecastReadModel {
+  /** @format int32 */
+  id?: number;
+  name?: string;
+  /** @format date */
+  startDate?: string | null;
+  /** @format date */
+  endDate?: string | null;
+  competences?: CompetenceReadModel[];
+  department?: DepartmentReadModel;
+  /** @format int32 */
+  yearsOfExperience?: number;
+  /** @format int32 */
+  graduationYear?: number;
+  degree?: Degree;
+  bookings?: BookedHoursInMonth[];
+  detailedBookings?: DetailedBookingForMonth[];
+  forecasts?: ForecastForMonth[];
+  isOccupied?: boolean;
+  imageThumbUrl?: string;
+}
+
+export interface BookedHoursInMonth {
+  /** @format date */
+  month?: string;
+  bookingModel?: MonthlyBookingReadModel;
+}
+
+export interface MonthlyBookingReadModel {
+  /** @format double */
+  totalBillable?: number;
+  /** @format double */
+  totalOffered?: number;
+  /** @format double */
+  totalPlannedAbsences?: number;
+  /** @format double */
+  totalExcludableAbsence?: number;
+  /** @format double */
+  totalSellableTime?: number;
+  /** @format double */
+  totalHolidayHours?: number;
+  /** @format double */
+  totalVacationHours?: number;
+  /** @format double */
+  totalOverbooking?: number;
+  /** @format double */
+  totalNotStartedOrQuit?: number;
+}
+
+export interface DetailedBookingForMonth {
+  bookingDetails?: BookingDetails;
+  hours?: MonthlyHours[];
+}
+
+export interface MonthlyHours {
+  /** @format date */
+  month?: string;
+  /** @format double */
+  hours?: number;
+}
+
+export interface ForecastForMonth {
+  /** @format date */
+  month?: string;
+  /** @format double */
+  calculatedPercentage?: number | null;
+  /** @format int32 */
+  displayedPercentage?: number | null;
+}

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -305,36 +305,36 @@ export interface CustomersWithProjectsReadModel {
 }
 
 export interface ForecastReadModel {
-  consultant?: SingleConsultantReadModel;
-  bookings?: BookedHoursInMonth[];
-  detailedBookings?: DetailedBookingForMonth[];
-  forecasts?: ForecastForMonth[];
-  consultantIsOccupied?: boolean;
+  consultant: SingleConsultantReadModel;
+  bookings: BookedHoursInMonth[];
+  detailedBookings: DetailedBookingForMonth[];
+  forecasts: ForecastForMonth[];
+  consultantIsOccupied: boolean;
 }
 
 export interface BookedHoursInMonth {
   /** @format date */
-  month?: string;
-  bookingModel?: BookingReadModel;
+  month: string;
+  bookingModel: BookingReadModel;
 }
 
 export interface DetailedBookingForMonth {
-  bookingDetails?: BookingDetails;
-  hours?: MonthlyHours[];
+  bookingDetails: BookingDetails;
+  hours: MonthlyHours[];
 }
 
 export interface MonthlyHours {
   /** @format date */
-  month?: string;
+  month: string;
   /** @format double */
-  hours?: number;
+  hours: number;
 }
 
 export interface ForecastForMonth {
   /** @format date */
-  month?: string;
+  month: string;
   /** @format double */
-  calculatedPercentage?: number | null;
+  calculatedPercentage: number;
   /** @format int32 */
-  displayedPercentage?: number | null;
+  displayedPercentage: number;
 }

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -324,28 +324,7 @@ export interface ForecastReadModel {
 export interface BookedHoursInMonth {
   /** @format date */
   month?: string;
-  bookingModel?: MonthlyBookingReadModel;
-}
-
-export interface MonthlyBookingReadModel {
-  /** @format double */
-  totalBillable?: number;
-  /** @format double */
-  totalOffered?: number;
-  /** @format double */
-  totalPlannedAbsences?: number;
-  /** @format double */
-  totalExcludableAbsence?: number;
-  /** @format double */
-  totalSellableTime?: number;
-  /** @format double */
-  totalHolidayHours?: number;
-  /** @format double */
-  totalVacationHours?: number;
-  /** @format double */
-  totalOverbooking?: number;
-  /** @format double */
-  totalNotStartedOrQuit?: number;
+  bookingModel?: BookingReadModel;
 }
 
 export interface DetailedBookingForMonth {

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -202,9 +202,14 @@ export interface SingleConsultantReadModel {
   name: string;
   /** @minLength 1 */
   email: string;
-  competences: string[];
-  /** @minLength 1 */
-  department: string;
+  /** @format date */
+  startDate: string;
+  /** @format date */
+  endDate: string;
+  competences: CompetenceReadModel[];
+  department: DepartmentReadModel;
+  /** @format int32 */
+  graduationYear: number;
   /** @format int32 */
   yearsOfExperience: number;
   degree: Degree;
@@ -300,25 +305,11 @@ export interface CustomersWithProjectsReadModel {
 }
 
 export interface ForecastReadModel {
-  /** @format int32 */
-  id?: number;
-  name?: string;
-  /** @format date */
-  startDate?: string | null;
-  /** @format date */
-  endDate?: string | null;
-  competences?: CompetenceReadModel[];
-  department?: DepartmentReadModel;
-  /** @format int32 */
-  yearsOfExperience?: number;
-  /** @format int32 */
-  graduationYear?: number;
-  degree?: Degree;
+  consultant?: SingleConsultantReadModel;
   bookings?: BookedHoursInMonth[];
   detailedBookings?: DetailedBookingForMonth[];
   forecasts?: ForecastForMonth[];
-  isOccupied?: boolean;
-  imageThumbUrl?: string;
+  consultantIsOccupied?: boolean;
 }
 
 export interface BookedHoursInMonth {

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -20,7 +20,7 @@ export interface BookedHoursPerWeek {
   sortableWeek: number;
   /** @minLength 1 */
   dateString: string;
-  bookingModel: WeeklyBookingReadModel;
+  bookingModel: BookingReadModel;
 }
 export interface BookingDetails {
   /** @minLength 1 */
@@ -263,7 +263,7 @@ export interface VacationReadModel {
   vacationMetaData?: VacationMetaData;
 }
 
-export interface WeeklyBookingReadModel {
+export interface BookingReadModel {
   /** @format double */
   totalBillable: number;
   /** @format double */

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -309,7 +309,7 @@ export interface ForecastReadModel {
   bookings: BookedHoursInMonth[];
   detailedBookings: DetailedBookingForMonth[];
   forecasts: ForecastForMonth[];
-  consultantIsOccupied: boolean;
+  consultantIsAvailable: boolean;
 }
 
 export interface BookedHoursInMonth {

--- a/frontend/src/components/Forecast/TransformWeekDataToMonth.ts
+++ b/frontend/src/components/Forecast/TransformWeekDataToMonth.ts
@@ -2,7 +2,7 @@ import {
   BookedHoursPerWeek,
   BookingDetails,
   DetailedBooking,
-  WeeklyBookingReadModel,
+  BookingReadModel,
 } from "@/api-types";
 import { getMonthOfWeek, weekToWeekType } from "./WeekToMonthConverter";
 import {
@@ -37,12 +37,12 @@ function transformToMonthlyData(weeklyData: BookedHoursPerWeek[]) {
 
     function distributeBookingModel(
       distribution: number,
-      bookingModel: WeeklyBookingReadModel,
-    ): WeeklyBookingReadModel {
-      const distributedModel: WeeklyBookingReadModel = { ...bookingModel };
+      bookingModel: BookingReadModel,
+    ): BookingReadModel {
+      const distributedModel: BookingReadModel = { ...bookingModel };
       for (const key of Object.keys(
         bookingModel,
-      ) as (keyof WeeklyBookingReadModel)[]) {
+      ) as (keyof BookingReadModel)[]) {
         distributedModel[key] = round2Decimals(
           bookingModel[key] * distribution,
         );
@@ -50,29 +50,29 @@ function transformToMonthlyData(weeklyData: BookedHoursPerWeek[]) {
       return distributedModel;
     }
 
-    const primaryBookingModel: WeeklyBookingReadModel = distributeBookingModel(
+    const primaryBookingModel: BookingReadModel = distributeBookingModel(
       primaryDistribution,
       bookingModel,
     );
-    const secondaryBookingModel: WeeklyBookingReadModel | null =
+    const secondaryBookingModel: BookingReadModel | null =
       secondaryMonthKey
         ? distributeBookingModel(secondaryDistribution, bookingModel)
         : null;
 
-    function addToMonthlyData(monthKey: string, model: WeeklyBookingReadModel) {
+    function addToMonthlyData(monthKey: string, model: BookingReadModel) {
       if (!monthlyData[monthKey]) {
         monthlyData[monthKey] = {
           year: year,
           month: parseInt(monthKey.split("-")[1]),
           bookingModel: Object.keys(model).reduce((acc, key) => {
-            acc[key as keyof WeeklyBookingReadModel] = 0;
+            acc[key as keyof BookingReadModel] = 0;
             return acc;
-          }, {} as WeeklyBookingReadModel),
+          }, {} as BookingReadModel),
         };
       }
       for (const key of Object.keys(
         model,
-      ) as (keyof WeeklyBookingReadModel)[]) {
+      ) as (keyof BookingReadModel)[]) {
         monthlyData[monthKey].bookingModel[key] += model[key];
       }
     }

--- a/frontend/src/components/Forecast/TransformWeekDataToMonth.ts
+++ b/frontend/src/components/Forecast/TransformWeekDataToMonth.ts
@@ -54,10 +54,9 @@ function transformToMonthlyData(weeklyData: BookedHoursPerWeek[]) {
       primaryDistribution,
       bookingModel,
     );
-    const secondaryBookingModel: BookingReadModel | null =
-      secondaryMonthKey
-        ? distributeBookingModel(secondaryDistribution, bookingModel)
-        : null;
+    const secondaryBookingModel: BookingReadModel | null = secondaryMonthKey
+      ? distributeBookingModel(secondaryDistribution, bookingModel)
+      : null;
 
     function addToMonthlyData(monthKey: string, model: BookingReadModel) {
       if (!monthlyData[monthKey]) {
@@ -70,9 +69,7 @@ function transformToMonthlyData(weeklyData: BookedHoursPerWeek[]) {
           }, {} as BookingReadModel),
         };
       }
-      for (const key of Object.keys(
-        model,
-      ) as (keyof BookingReadModel)[]) {
+      for (const key of Object.keys(model) as (keyof BookingReadModel)[]) {
         monthlyData[monthKey].bookingModel[key] += model[key];
       }
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,7 +3,7 @@ import {
   BookingType,
   ConsultantReadModel,
   EngagementState,
-  WeeklyBookingReadModel,
+  BookingReadModel,
 } from "@/api-types";
 
 export type YearRange = {
@@ -34,7 +34,7 @@ export interface Month {
 export interface BookedHoursPerMonth {
   month: number;
   year: number;
-  bookingModel: WeeklyBookingReadModel;
+  bookingModel: BookingReadModel;
 }
 
 export interface Forecast {


### PR DESCRIPTION
- Creating `ForecastReadModel` and associated models in backend
- Generating `ForecastReadModel` and associated models in frontend based on the backend models, using [swagger-typescript-api](https://github.com/acacode/swagger-typescript-api)
  - The models were generated in a larger file and moved to the already existing `api-types.ts` file for simplicity
  - The properties in the generated types have been set as being _not undefinable_ manually (i.e. removing the `?` following the data type), seeing as the generated properties deviated from the backend/source properties
- Renaming `WeeklyBookingReadModel` &rarr; `BookingReadModel`