### PR TITLE
Ensure proper width and height in monthcell and remove unused code

### DIFF
--- a/frontend/src/components/Forecast/ForecastRows.tsx
+++ b/frontend/src/components/Forecast/ForecastRows.tsx
@@ -99,7 +99,7 @@ export default function ForecastRows({
         onMouseEnter={() => setIsRowHovered(true)}
         onMouseLeave={() => setIsRowHovered(false)}
       >
-        <td
+        {/* <td
           className={`border-l-2 ${
             isListElementVisible
               ? "border-l-secondary"
@@ -108,15 +108,15 @@ export default function ForecastRows({
               : "border-l-primary/5"
           } `}
         >
-          {/* //utkommentert foreløpig, kan slettes om vi ikke skal ha mulighet til å utvide raden <button
+          //utkommentert foreløpig, kan slettes om vi ikke skal ha mulighet til å utvide raden <button
             className={`p-2 rounded-lg ml-2 hover:bg-primary hover:bg-opacity-10 ${
               isListElementVisible && "rotate-180"
             }`}
             onClick={toggleListElementVisibility}
           >
             <ChevronDown className={`text-primary w-6 h-6`} />
-          </button> */}
-        </td>
+          </button>
+        </td> */}
         <td>
           <div className="flex justify-start gap-1 items-center">
             <div className="flex flex-row justify-center self-center gap-2 w-3/12">
@@ -167,67 +167,6 @@ export default function ForecastRows({
           />
         ))}
       </tr>
-      {isListElementVisible &&
-        currentConsultant.detailedBooking &&
-        currentConsultant.detailedBooking.map((db, index) => (
-          <DetailedBookingRows
-            key={index}
-            consultant={currentConsultant}
-            detailedBooking={db}
-            openEngagementAndSetID={openEngagementAndSetID}
-            numWorkHours={numWorkHours}
-          />
-        ))}
-      {isListElementVisible && addNewRow && (
-        <tr>
-          <td
-            className={`border-l-2 ${
-              isListElementVisible
-                ? "border-l-secondary"
-                : isRowHovered
-                ? "border-l-primary"
-                : "border-l-primary/5"
-            } `}
-          ></td>
-        </tr>
-      )}
-
-      {isListElementVisible && (
-        <tr>
-          <td
-            className={`border-l-2 ${
-              isListElementVisible
-                ? "border-l-secondary"
-                : isRowHovered
-                ? "border-l-primary"
-                : "border-l-primary/5"
-            } `}
-          ></td>
-          <td>
-            {!addNewRow && (
-              <button
-                onClick={() => {
-                  setAddNewRow(true);
-                  setIsDisabledHotkeys(true);
-                }}
-                className="flex flex-row items-center min-w-max gap-2 h-[52px]"
-                onMouseEnter={() => setIsAddStaffingHovered(true)}
-                onMouseLeave={() => setIsAddStaffingHovered(false)}
-              >
-                <span
-                  className={`w-8 h-8 flex justify-center items-center rounded bg-primary/0 ${
-                    isAddStaffingHovered && "bg-primary/10"
-                  }`}
-                >
-                  <Plus size={16} className="text-primary" />
-                </span>
-
-                <p className="small text-primary">Legg til bemanning</p>
-              </button>
-            )}
-          </td>
-        </tr>
-      )}
     </>
   );
 }

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -75,15 +75,14 @@ export default function ForecastTable() {
   return (
     <table className={`table-fixed`}>
       <colgroup>
-        <col span={1} className="w-14" />
         <col span={1} className="w-[190px]" />
-        {filteredConsultants
-          .at(0)
-          ?.bookings.map((_, index) => <col key={index} span={1} />)}
+        {monthsWithYears.map((_, index) => (
+          <col key={index} span={1} className="w-[calc((1%/15)*100)]" />
+        ))}
       </colgroup>
       <thead>
         <tr className="sticky -top-6 bg-white z-10">
-          <th colSpan={2} className="pt-3 pl-2 -left-2 relative bg-white">
+          <th colSpan={1} className="pt-3 pl-2 -left-2 relative bg-white">
             <div className="flex flex-row gap-3 pb-4 items-center">
               <p className="normal-medium ">Konsulenter</p>
               <p className="text-primary small-medium rounded-full bg-secondary/30 px-2 py-1">

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -77,7 +77,11 @@ export default function ForecastTable() {
       <colgroup>
         <col span={1} className="w-[190px]" />
         {monthsWithYears.map((_, index) => (
-          <col key={index} span={1} className="w-[calc((1%/15)*100)]" />
+          <col
+            key={index}
+            span={1}
+            className={`w-[calc((1%/${monthsWithYears.length + 3})*100)]`}
+          />
         ))}
       </colgroup>
       <thead>

--- a/frontend/src/components/Forecast/MonthCell.tsx
+++ b/frontend/src/components/Forecast/MonthCell.tsx
@@ -99,7 +99,11 @@ export function MonthCell(props: {
   }
 
   return (
-    <td key={month} className={`h-[52px] relative`} ref={ref}>
+    <td
+      key={month}
+      className={`h-[56px] relative ${isLastCol ? "py-0.5 pl-0.5" : "p-0.5"}`}
+      ref={ref}
+    >
       <div
         className={`flex bg-primary/[3%] flex-col gap-1 p-2 justify-end rounded w-full h-full relative border border-transparent hover:border-primary/30 `}
         onMouseEnter={() => {
@@ -165,7 +169,7 @@ export function MonthCell(props: {
         </div>
       </div>
       {isActive && (
-        <ul className="flex flex-col border border-primary/30 rounded mt-0.5 absolute w-[99%] items-end bg-white opacity-100 z-50">
+        <ul className="flex flex-col border border-primary/30 rounded mt-1 absolute w-[calc(100%-0.25rem)] justify-center items-end bg-white opacity-100 z-50">
           {options.map((opt, index) => (
             <li
               key={opt.toString()}


### PR DESCRIPTION
Fixes differences in widths and heights of the month cells. I removed some unused code that followed from copying `WeekCell`. 

# To reviewer
The calculation of the width of the cell is done in the tables' colgroup as widths in tables are finicky. The calculation of the widths is based on logic (🤯) that is as follows: we are supposed to always display 13 months (or 12?), providing a suggestion to use (1/13)*100% as the width of the colgroup, however this led to a very squished colgroup for the consultant name, because the months took up too much space, therefore i ended up using (1/15)/100% as the width of the months. This ensured that the consultant name and image had enough space even on smaller laptops. 

EDIT: changed it to `w-[calc((1%/${monthsWithYears.length + 3})*100)]` as this will future proof for showing more or less months 

# Before
<img width="1523" alt="Screenshot 2025-01-22 at 14 58 57" src="https://github.com/user-attachments/assets/2a726a72-75a4-4be8-860c-97e01b0c1bff" />

# After
<img width="1539" alt="Screenshot 2025-01-22 at 14 59 18" src="https://github.com/user-attachments/assets/44c75a05-f4cf-4aa0-9e2f-06430f446044" />

