### PR TITLE
Adding the numerator and denominator used in the forecast calcuation to the ForecastForMonth object

### DIFF
--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -64,4 +64,52 @@ public record struct MonthlyHours(DateOnly Month, double Hours)
 	}
 }
 
-public record ForecastForMonth(DateOnly Month, int BillablePercentage, int DisplayedPercentage);
+public record ForecastForMonth(DateOnly Month, int BillablePercentage, int DisplayedPercentage)
+{
+	public static ForecastForMonth GetForecast(Consultant consultant, DateOnly month, List<BookedHoursInMonth> bookingSummary)
+	{
+		var forecastPercentage = consultant.Forecasts
+			.SingleOrDefault(f => f.Month.EqualsMonth(month))?
+			.AdjustedValue ?? 0;
+
+		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.EqualsMonth(month));
+
+		if (booking == null)
+		{
+			return new ForecastForMonth(month, 0, forecastPercentage);
+		}
+
+		var billablePercentage = GetBillablePercentage(month, consultant, booking.BookingModel);
+
+		var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
+
+		return new ForecastForMonth(month, billablePercentage, displayedPercentage);
+	}
+
+	private static int GetBillablePercentage(DateOnly month, Consultant consultant, BookingReadModel booking)
+	{
+		var hoursOrganizationCanBillCustomer = booking.TotalBillable;
+
+		if (hoursOrganizationCanBillCustomer.IsEqualTo(0))
+		{
+			return 0;
+		}
+
+		var hoursInMonth = consultant.Department.Organization.GetTotalWeekdayHoursInMonth(month);
+
+		var hoursConsultantIsPaidByOrganization = hoursInMonth
+		                                          - booking.TotalHolidayHours
+		                                          - booking.TotalVacationHours
+		                                          - booking.TotalExcludableAbsence
+		                                          - booking.TotalNotStartedOrQuit;
+
+		if (hoursOrganizationCanBillCustomer.IsGreaterThanOrEqualTo(hoursConsultantIsPaidByOrganization))
+		{
+			return 100;
+		}
+
+		var billableRate = hoursOrganizationCanBillCustomer / hoursConsultantIsPaidByOrganization;
+
+		return (int)(100 * billableRate);
+	}
+}

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -64,7 +64,12 @@ public record struct MonthlyHours(DateOnly Month, double Hours)
 	}
 }
 
-public record ForecastForMonth(DateOnly Month, int BillablePercentage, int DisplayedPercentage)
+public record ForecastForMonth(
+	DateOnly Month,
+	double BillableHours,
+	double SalariedHours,
+	int BillablePercentage,
+	int DisplayedPercentage)
 {
 	public static ForecastForMonth GetForecast(Consultant consultant, DateOnly month, List<BookedHoursInMonth> bookingSummary)
 	{
@@ -85,12 +90,12 @@ public record ForecastForMonth(DateOnly Month, int BillablePercentage, int Displ
 		var billablePercentage = GetBillablePercentage(billableHours, salariedHours);
 		var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
 
-		return new ForecastForMonth(month, billablePercentage, displayedPercentage);
+		return new ForecastForMonth(month, billableHours, salariedHours, billablePercentage, displayedPercentage);
 	}
 
 	private static ForecastForMonth WithoutBookingInfo(DateOnly month, int displayedPercentage)
 	{
-		return new ForecastForMonth(month, 0, displayedPercentage);
+		return new ForecastForMonth(month, 0, 0, 0, displayedPercentage);
 	}
 
 	private static double GetBillableHours(BookingReadModel booking)

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -88,27 +88,27 @@ public record ForecastForMonth(DateOnly Month, int BillablePercentage, int Displ
 
 	private static int GetBillablePercentage(DateOnly month, Consultant consultant, BookingReadModel booking)
 	{
-		var hoursOrganizationCanBillCustomer = booking.TotalBillable;
+		var billableHours = booking.TotalBillable;
 
-		if (hoursOrganizationCanBillCustomer.IsEqualTo(0))
+		if (billableHours.IsEqualTo(0))
 		{
 			return 0;
 		}
 
 		var hoursInMonth = consultant.Department.Organization.GetTotalWeekdayHoursInMonth(month);
 
-		var hoursConsultantIsPaidByOrganization = hoursInMonth
-		                                          - booking.TotalHolidayHours
-		                                          - booking.TotalVacationHours
-		                                          - booking.TotalExcludableAbsence
-		                                          - booking.TotalNotStartedOrQuit;
+		var salariedHours = hoursInMonth
+		                    - booking.TotalHolidayHours
+		                    - booking.TotalVacationHours
+		                    - booking.TotalExcludableAbsence
+		                    - booking.TotalNotStartedOrQuit;
 
-		if (hoursOrganizationCanBillCustomer.IsGreaterThanOrEqualTo(hoursConsultantIsPaidByOrganization))
+		if (billableHours.IsGreaterThanOrEqualTo(salariedHours))
 		{
 			return 100;
 		}
 
-		var billableRate = hoursOrganizationCanBillCustomer / hoursConsultantIsPaidByOrganization;
+		var billableRate = billableHours / salariedHours;
 
 		return (int)(100 * billableRate);
 	}

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -76,7 +76,7 @@ public record ForecastForMonth(DateOnly Month, int BillablePercentage, int Displ
 
 		if (booking == null)
 		{
-			return new ForecastForMonth(month, 0, forecastPercentage);
+			return WithoutBookingInfo(month, forecastPercentage);
 		}
 
 		var billablePercentage = GetBillablePercentage(month, consultant, booking.BookingModel);
@@ -84,6 +84,11 @@ public record ForecastForMonth(DateOnly Month, int BillablePercentage, int Displ
 		var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
 
 		return new ForecastForMonth(month, billablePercentage, displayedPercentage);
+	}
+
+	private static ForecastForMonth WithoutBookingInfo(DateOnly month, int displayedPercentage)
+	{
+		return new ForecastForMonth(month, 0, displayedPercentage);
 	}
 
 	private static double GetBillableHours(BookingReadModel booking)

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -71,9 +71,9 @@ public record ForecastForMonth(
 	int BillablePercentage,
 	int DisplayedPercentage)
 {
-	public static ForecastForMonth GetForecast(Consultant consultant, DateOnly month, List<BookedHoursInMonth> bookingSummary)
+	public static ForecastForMonth GetFor(Consultant consultant, DateOnly month, IEnumerable<BookedHoursInMonth> bookingSummary)
 	{
-		var forecastPercentage = consultant.Forecasts
+		var manuallySetPercentage = consultant.Forecasts
 			.SingleOrDefault(f => f.Month.EqualsMonth(month))?
 			.AdjustedValue ?? 0;
 
@@ -81,14 +81,14 @@ public record ForecastForMonth(
 
 		if (booking == null)
 		{
-			return WithoutBookingInfo(month, forecastPercentage);
+			return WithoutBookingInfo(month, manuallySetPercentage);
 		}
 
 		var billableHours = GetBillableHours(booking);
 		var salariedHours = GetSalariedHoursForMonth(month, consultant, booking);
 
 		var billablePercentage = GetBillablePercentage(billableHours, salariedHours);
-		var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
+		var displayedPercentage = Math.Max(billablePercentage, manuallySetPercentage);
 
 		return new ForecastForMonth(month, billableHours, salariedHours, billablePercentage, displayedPercentage);
 	}

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -32,7 +32,9 @@ public static class ConsultantWithForecastFactory
 			.Select(month => GetBookedHours(consultant, month, detailedBookings))
 			.ToList();
 
-		var forecasts = GetForecasts(consultant, months, bookingSummary).ToList();
+		var forecasts = months
+			.Select(month => GetForecast(consultant, month, bookingSummary))
+			.ToList();
 
 		var isAvailable = bookingSummary.Any(bs => bs.BookingModel.TotalSellableTime.IsGreaterThan(0));
 
@@ -174,28 +176,24 @@ public static class ConsultantWithForecastFactory
 		);
 	}
 
-	private static IEnumerable<ForecastForMonth> GetForecasts(Consultant consultant, List<DateOnly> months, List<BookedHoursInMonth> bookingSummary)
+	private static ForecastForMonth GetForecast(Consultant consultant, DateOnly month, List<BookedHoursInMonth> bookingSummary)
 	{
-		foreach (var month in months)
+		var forecastPercentage = consultant.Forecasts
+			.SingleOrDefault(f => f.Month.EqualsMonth(month))?
+			.AdjustedValue ?? 0;
+
+		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.EqualsMonth(month));
+
+		if (booking == null)
 		{
-			var forecastPercentage = consultant.Forecasts
-				.SingleOrDefault(f => f.Month.EqualsMonth(month))?
-				.AdjustedValue ?? 0;
-
-			var booking = bookingSummary.SingleOrDefault(bs => bs.Month.EqualsMonth(month));
-
-			if (booking == null)
-			{
-				yield return new ForecastForMonth(month, 0, forecastPercentage);
-				continue;
-			}
-
-			var billablePercentage = GetBillablePercentage(month, consultant, booking.BookingModel);
-
-			var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
-
-			yield return new ForecastForMonth(month, billablePercentage, displayedPercentage);
+			return new ForecastForMonth(month, 0, forecastPercentage);
 		}
+
+		var billablePercentage = GetBillablePercentage(month, consultant, booking.BookingModel);
+
+		var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
+
+		return new ForecastForMonth(month, billablePercentage, displayedPercentage);
 	}
 
 	private static int GetBillablePercentage(DateOnly month, Consultant consultant, BookingReadModel booking)

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -33,7 +33,7 @@ public static class ConsultantWithForecastFactory
 			.ToList();
 
 		var forecasts = months
-			.Select(month => GetForecast(consultant, month, bookingSummary))
+			.Select(month => ForecastForMonth.GetForecast(consultant, month, bookingSummary))
 			.ToList();
 
 		var isAvailable = bookingSummary.Any(bs => bs.BookingModel.TotalSellableTime.IsGreaterThan(0));
@@ -174,52 +174,5 @@ public static class ConsultantWithForecastFactory
 				overbookedHours,
 				totalNotStartedOrQuit)
 		);
-	}
-
-	private static ForecastForMonth GetForecast(Consultant consultant, DateOnly month, List<BookedHoursInMonth> bookingSummary)
-	{
-		var forecastPercentage = consultant.Forecasts
-			.SingleOrDefault(f => f.Month.EqualsMonth(month))?
-			.AdjustedValue ?? 0;
-
-		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.EqualsMonth(month));
-
-		if (booking == null)
-		{
-			return new ForecastForMonth(month, 0, forecastPercentage);
-		}
-
-		var billablePercentage = GetBillablePercentage(month, consultant, booking.BookingModel);
-
-		var displayedPercentage = Math.Max(billablePercentage, forecastPercentage);
-
-		return new ForecastForMonth(month, billablePercentage, displayedPercentage);
-	}
-
-	private static int GetBillablePercentage(DateOnly month, Consultant consultant, BookingReadModel booking)
-	{
-		var hoursOrganizationCanBillCustomer = booking.TotalBillable;
-
-		if (hoursOrganizationCanBillCustomer.IsEqualTo(0))
-		{
-			return 0;
-		}
-
-		var hoursInMonth = consultant.Department.Organization.GetTotalWeekdayHoursInMonth(month);
-
-		var hoursConsultantIsPaidByOrganization = hoursInMonth
-		                                          - booking.TotalHolidayHours
-		                                          - booking.TotalVacationHours
-		                                          - booking.TotalExcludableAbsence
-		                                          - booking.TotalNotStartedOrQuit;
-
-		if (hoursOrganizationCanBillCustomer.IsGreaterThanOrEqualTo(hoursConsultantIsPaidByOrganization))
-		{
-			return 100;
-		}
-
-		var billableRate = hoursOrganizationCanBillCustomer / hoursConsultantIsPaidByOrganization;
-
-		return (int)(100 * billableRate);
 	}
 }

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -33,7 +33,7 @@ public static class ConsultantWithForecastFactory
 			.ToList();
 
 		var forecasts = months
-			.Select(month => ForecastForMonth.GetForecast(consultant, month, bookingSummary))
+			.Select(month => ForecastForMonth.GetFor(consultant, month, bookingSummary))
 			.ToList();
 
 		var isAvailable = bookingSummary.Any(bs => bs.BookingModel.TotalSellableTime.IsGreaterThan(0));

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -330,6 +330,10 @@ export interface MonthlyHours {
 export interface ForecastForMonth {
   /** @format date */
   month: string;
+  /** @format double */
+  billableHours: number;
+  /** @format double */
+  salariedHours: number;
   /** @format int32 */
   billablePercentage: number;
   /** @format int32 */


### PR DESCRIPTION
Extending the `ForecastForMonth` type with two properties:
- `double BillableHours`: the numerator used in the calculation of `BillablePercentage`
- `double SalariedHours`: the denominator used in the calculation of `BillablePercentage`

To facilitate the construction of `ForecastForMonth` objects containing these properties, some logic has been restructured and moved from the `ConsultantWithForecastFactory` class to the `ForecastForMonth` record.

Review one commit at a time to follow the changes more easily.
