### PR TITLE
Bugfix: Add new engagement cell count

### DIFF
--- a/frontend/src/components/Staffing/ConsultantRow.tsx
+++ b/frontend/src/components/Staffing/ConsultantRow.tsx
@@ -56,6 +56,10 @@ export default function ConsultantRows({
     }
   }, [consultant.bookings.length, consultant]);
 
+  useEffect(() => {
+    setNewWeekList(weekList);
+  }, [weekList]);
+
   const columnCount = currentConsultant.bookings.length ?? 0;
 
   function toggleListElementVisibility() {


### PR DESCRIPTION
Previously, if one changed to 26-week view and then added a new engagement to a consultant, the number of cells for the working hours showed would be 8, not 26. This is fixed here 