### PR TITLE
Bugfix: Set default availabilityFilter state properly

### DIFF
--- a/frontend/src/hooks/ConsultantFilterProvider.tsx
+++ b/frontend/src/hooks/ConsultantFilterProvider.tsx
@@ -127,7 +127,7 @@ function useUrlRouteFilter(): [StaffingFilters, UpdateFilters] {
     searchParams.get("experienceToFilter") || "",
   );
   const [availabilityFilter, setAvailabilityFilter] = useState<boolean>(
-    !!searchParams.get("availabilityFilter") || false,
+    searchParams.get("availabilityFilter") === "true",
   );
   const [selectedWeek, setSelectedWeek] = useState(
     parseYearWeekFromUrlString(searchParams.get("selectedWeek") || undefined),


### PR DESCRIPTION
Currently if you visit bemanning and reload, the "availability filter" will appear to automatically become enabled, this PR fixes that. 