### PR TITLE
Remove redundant session check in callApi

### DIFF
--- a/frontend/src/data/apiCallsWithToken.ts
+++ b/frontend/src/data/apiCallsWithToken.ts
@@ -63,10 +63,6 @@ export async function callApi<T, Body>(
   if (process.env.NEXT_PUBLIC_NO_AUTH) {
     return mockedCall<T>(path);
   }
-  const session = await getCustomServerSession(authOptions);
-
-  if (!session || !session.access_token) return;
-
   try {
     const response = await callApiNoParse(path, method, bodyInit);
     if (!response || response.status == 204 || !response.ok) {

--- a/frontend/src/data/apiCallsWithToken.ts
+++ b/frontend/src/data/apiCallsWithToken.ts
@@ -63,26 +63,22 @@ export async function callApi<T, Body>(
   if (process.env.NEXT_PUBLIC_NO_AUTH) {
     return mockedCall<T>(path);
   }
-  try {
-    const response = await callApiNoParse(path, method, bodyInit);
-    if (!response || response.status == 204 || !response.ok) {
-      const responseText = await response?.text();
-      console.error(`Failed from ${path}. Response text: ${responseText}`);
-      return;
-    }
-    const contentType = response.headers.get("Content-Type");
-    let result: T;
-
-    if (contentType && contentType.includes("application/json")) {
-      result = await response.json();
-    } else {
-      result = (await response.text()) as unknown as T;
-    }
-
-    return result as T;
-  } catch (e) {
-    throw new Error(`${method} ${path} failed`);
+  const response = await callApiNoParse(path, method, bodyInit);
+  if (!response || response.status == 204 || !response.ok) {
+    const responseText = await response?.text();
+    console.error(`Failed from ${path}. Response text: ${responseText}`);
+    return;
   }
+  const contentType = response.headers.get("Content-Type");
+  let result: T;
+
+  if (contentType && contentType.includes("application/json")) {
+    result = await response.json();
+  } else {
+    result = (await response.text()) as unknown as T;
+  }
+
+  return result as T;
 }
 
 export async function fetchWithToken<ReturnType>(
@@ -134,6 +130,7 @@ async function fetchWithTimeoutOrNull<T>(
     return null;
   }
 }
+
 export async function callForecastEmployee(path: string) {
   if (process.env.NEXT_PUBLIC_NO_AUTH) {
     return mockedCall<undefined>(path);


### PR DESCRIPTION
The same session check is present in `callApiNoParse`, which `callApi` always calls anyway, making it redundant.

I've ran some timing tests locally, and the `getCustomServerSession` call seems to take anywhere from 150 ms to 500 ms. This means we can shave off non-trivial time pretty much for free with this change.