### PR TITLE
Fix blinking in customer table

### DIFF
--- a/frontend/src/components/CustomerTable/CustomerTable.tsx
+++ b/frontend/src/components/CustomerTable/CustomerTable.tsx
@@ -114,7 +114,17 @@ export default function CustomerTable({
         />
 
         <tbody>
-          <EngagementsRows engagements={customer.activeEngagements} />
+          {customer.activeEngagements.map((engagement) => (
+            <EngagementRow
+              key={engagement.engagementId}
+              engagement={engagement}
+              orgUrl={orgUrl}
+              selectedWeek={selectedWeek}
+              selectedWeekSpan={selectedWeekSpan}
+              weekList={weekList}
+              numWorkHours={numWorkHours}
+            />
+          ))}
 
           <tr>
             <td colSpan={2}>
@@ -127,32 +137,20 @@ export default function CustomerTable({
             </td>
           </tr>
 
-          <EngagementsRows engagements={customer.inactiveEngagements} />
+          {customer.inactiveEngagements.map((inactiveEngagement) => (
+            <EngagementRow
+              key={inactiveEngagement.engagementId}
+              engagement={inactiveEngagement}
+              orgUrl={orgUrl}
+              selectedWeek={selectedWeek}
+              selectedWeekSpan={selectedWeekSpan}
+              weekList={weekList}
+              numWorkHours={numWorkHours}
+            />
+          ))}
         </tbody>
       </table>
       <AgreementEdit customer={customer} />
     </div>
   );
-
-  function EngagementsRows({
-    engagements,
-  }: {
-    engagements: EngagementReadModel[];
-  }) {
-    return (
-      <>
-        {engagements.map((engagement) => (
-          <EngagementRow
-            key={engagement.engagementId}
-            engagement={engagement}
-            orgUrl={orgUrl}
-            selectedWeek={selectedWeek}
-            selectedWeekSpan={selectedWeekSpan}
-            weekList={weekList}
-            numWorkHours={numWorkHours}
-          />
-        ))}
-      </>
-    );
-  }
 }


### PR DESCRIPTION
This PR fixes the issue where the number of consultants would 'blink' when entering the customer page. The component `<EngagementsRows>` was placed inside the `<CustomerTable>` component resulting in some rendering issues. I removed the `<EngagementsRows>`  component and mapped the engagements straight inside the `<CustomerTable>` instead. 

Closes #664 