### PR TITLE
Fix staffing multiple tab update bug

### DIFF
--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -149,7 +149,14 @@ export function upsertConsultantBooking(
           consultantToUpdate.detailedBooking.length > 0 &&
           consultantToUpdate.detailedBooking[0].hours.length > 0
         ) {
-          const hours = consultantToUpdate.detailedBooking[0].hours;
+          // Get week numbers
+          const hours = consultantToUpdate.detailedBooking[0].hours.map(
+            (hour) => ({
+              hours: 0,
+              week: hour.week,
+            }),
+          );
+
           for (const h of detailedBooking.hours) {
             for (let i = 0; i < hours.length; i++) {
               if (hours[i].week === h.week) {

--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -160,7 +160,7 @@ export function upsertConsultantBooking(
           }
           detailedBooking.hours = hours;
         }
-        consultantToUpdate.detailedBooking[bookingIndex] = detailedBooking;
+        consultantToUpdate.detailedBooking.push(detailedBooking);
         old[consultantIndex] = consultantToUpdate;
         return [...old];
       }

--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -159,7 +159,8 @@ export function upsertConsultantBooking(
           detailedBooking.hours = hours;
         }
         consultantToUpdate.detailedBooking[bookingIndex] = detailedBooking;
-        return;
+        old[consultantIndex] = consultantToUpdate;
+        return [...old];
       }
 
       detailedBooking.hours.map((hour) => {

--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -121,6 +121,8 @@ export function upsertConsultantBooking(
   const consultantToUpdate = old.find((c) => c.id === res.id);
   if (!consultantToUpdate || !res) return old;
 
+  const consultantIndex = old.findIndex((c) => c.id === res.id);
+
   consultantToUpdate.bookings = consultantToUpdate.bookings ?? [];
   res.bookings?.map((booking) => {
     const bookingIndex = consultantToUpdate.bookings.findIndex(
@@ -174,7 +176,6 @@ export function upsertConsultantBooking(
     });
   }
 
-  const consultantIndex = old.findIndex((c) => c.id === res.id);
   old[consultantIndex] = consultantToUpdate;
 
   return [...old];

--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -143,12 +143,11 @@ export function upsertConsultantBooking(
       if (detailedBookingIndex === -1) {
         // Either staffing or vacation was changed in a different tab since `old` was initially loaded.
         // Attempt to manually update the new data for the current week from `res`.
-        let hours = [];
         if (
           consultantToUpdate.detailedBooking.length > 0 &&
           consultantToUpdate.detailedBooking[0].hours.length > 0
         ) {
-          hours = consultantToUpdate.detailedBooking[0].hours;
+          const hours = consultantToUpdate.detailedBooking[0].hours;
           for (const h of detailedBooking.hours) {
             for (let i = 0; i < hours.length; i++) {
               if (hours[i].week === h.week) {

--- a/frontend/src/components/Staffing/helpers/utils.tsx
+++ b/frontend/src/components/Staffing/helpers/utils.tsx
@@ -135,7 +135,7 @@ export function upsertConsultantBooking(
   });
   if (res.detailedBooking) {
     res.detailedBooking.map((detailedBooking, bookingIndex) => {
-      let detailedBookingIndex = consultantToUpdate.detailedBooking.findIndex(
+      const detailedBookingIndex = consultantToUpdate.detailedBooking.findIndex(
         (db) =>
           db.bookingDetails.projectId ==
           detailedBooking.bookingDetails.projectId,


### PR DESCRIPTION
Fixes the following bug:

1. Open bemanning, then open ferie in another tab
2. In the Ferie tab: Find a week which has no vacation, add a vacation day for this week
3. In the bemanning tab: Add hours to one of your projects in the same week
4. The page will crash

The same applies to adding hours to a new project, then going back to an old tab and updating hours.