### PR TITLE
Hiding week numbers from vacation calendar

### DIFF
--- a/frontend/src/components/VacationCalendar.tsx
+++ b/frontend/src/components/VacationCalendar.tsx
@@ -201,7 +201,6 @@ export default function VacationCalendar({
             multiple
             fullYear
             weekStartDayIndex={1}
-            displayWeekNumbers
             currentDate={today}
             value={value}
             onChange={handleChange}


### PR DESCRIPTION
...due to the displayed week numbers being incorrect for some years. Displaying incorrect week numbers may result in consultants registering their vacation on the wrong dates.

[Here is a GitHub issue](https://github.com/shahabyazdi/date-object/issues/15) explaining the situation.