### PR TITLE
Adding frontend logic for "Faggrupper"

### DIFF
--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -51,6 +51,7 @@ export interface ConsultantReadModel {
   startDate?: Date;
   endDate?: Date;
   competences: Competence[];
+  discipline?: DisciplineReadModel;
   /** @minLength 1 */
   department: DepartmentReadModel;
   /** @format int32 */
@@ -111,6 +112,13 @@ export interface DepartmentReadModel {
 }
 
 export interface CompetenceReadModel {
+  /** @minLength 1 */
+  id: string;
+  /** @minLength 1 */
+  name: string;
+}
+
+export interface DisciplineReadModel {
   /** @minLength 1 */
   id: string;
   /** @minLength 1 */
@@ -208,6 +216,7 @@ export interface SingleConsultantReadModel {
   /** @format date */
   endDate: string;
   competences: CompetenceReadModel[];
+  discipline?: DisciplineReadModel;
   department: DepartmentReadModel;
   /** @format int32 */
   graduationYear: number;

--- a/frontend/src/app/[organisation]/bemanning/page.tsx
+++ b/frontend/src/app/[organisation]/bemanning/page.tsx
@@ -52,6 +52,7 @@ export default async function Bemanning({
       consultants={consultants ?? []}
       departments={departments ?? []}
       competences={competences ?? []}
+      disciplines={[]}
       customers={customers ?? []}
     >
       <StaffingContent />

--- a/frontend/src/app/[organisation]/konsulenter/page.tsx
+++ b/frontend/src/app/[organisation]/konsulenter/page.tsx
@@ -2,6 +2,7 @@ import {
   CompetenceReadModel,
   ConsultantReadModel,
   DepartmentReadModel,
+  DisciplineReadModel,
 } from "@/api-types";
 import ConsultantsContent from "@/components/consultants/ConsultantsContent";
 import {
@@ -20,12 +21,13 @@ export default async function Konsulenter({
 }: {
   params: { organisation: string };
 }) {
-  const [consultants, departments, competences] = await Promise.all([
+  const [consultants, departments, competences, disciplines] = await Promise.all([
     fetchEmployeesWithImageAndToken(`${params.organisation}/consultants`),
     fetchWithToken<DepartmentReadModel[]>(
       `organisations/${params.organisation}/departments`,
     ),
     fetchWithToken<CompetenceReadModel[]>(`competences`),
+    fetchWithToken<DisciplineReadModel[]>(`disciplines`),
   ]);
 
   return (
@@ -33,6 +35,7 @@ export default async function Konsulenter({
       consultants={consultants ?? []}
       departments={departments ?? []}
       competences={competences ?? []}
+      disciplines={disciplines ?? []}
       customers={[]}
     >
       <ConsultantsContent />

--- a/frontend/src/app/[organisation]/kunder/[customer]/content.tsx
+++ b/frontend/src/app/[organisation]/kunder/[customer]/content.tsx
@@ -49,6 +49,7 @@ export function CustomerPageContent(props: Props) {
     <ConsultantFilterProvider
       consultants={[]}
       competences={[]}
+      disciplines={[]}
       departments={departments ?? []}
       customers={[]}
     >

--- a/frontend/src/app/[organisation]/prosjekt/[project]/page.tsx
+++ b/frontend/src/app/[organisation]/prosjekt/[project]/page.tsx
@@ -75,6 +75,7 @@ export default function Project({
         consultants={consultants ?? []}
         departments={[]}
         competences={[]}
+        disciplines={[]}
         customers={[]}
       >
         <Sidebar project={project} />

--- a/frontend/src/app/[organisation]/rapport/page.tsx
+++ b/frontend/src/app/[organisation]/rapport/page.tsx
@@ -48,6 +48,7 @@ export default async function Rapport({
       consultants={consultants ?? []}
       departments={departments ?? []}
       competences={competences ?? []}
+      disciplines={[]}
       customers={customers ?? []}
     >
       <ReportContent />

--- a/frontend/src/components/consultants/EditableTableSingleSelectCell.tsx
+++ b/frontend/src/components/consultants/EditableTableSingleSelectCell.tsx
@@ -1,0 +1,87 @@
+import Select, { SingleValue } from "react-select";
+import React, { useEffect, useState } from "react";
+
+export default function EditableTableSingleSelectCell<T extends { id: string, name: string }>({
+  originalSelection,
+  setConsultant,
+  isEditing,
+  options,
+}: {
+  originalSelection: T | undefined;
+  setConsultant: (selectedOption: T | undefined) => void;
+  isEditing: boolean;
+  options: T[];
+}) {
+  const [newSelection, setNewSelection] =
+    useState<T | undefined>(originalSelection);
+
+  const [selection, setSelection] = useState<{
+    value: string;
+    label: string;
+  }>({
+    value: originalSelection?.id ?? '',
+    label: originalSelection?.name ?? '',
+  });
+
+  const selectOptions = options.map((option) => ({
+    value: option.id,
+    label: option.name,
+  }));
+
+  useEffect(() => {
+    if (isEditing) {
+      setSelection({
+        value: newSelection?.id ?? '',
+        label: newSelection?.name ?? '',
+      });
+      setConsultant(newSelection);
+    }
+  }, [newSelection]);
+
+  return (
+    <td className="pr-3">
+      {isEditing ? (
+        <Select
+          styles={{
+            valueContainer: (provided: any) => ({
+              ...provided,
+              // Set a maximum height
+              overflow: "auto", // Enable scrolling
+              maxHeight: "37px",
+            }),
+            control: (baseStyles, state) => ({
+              ...baseStyles,
+              borderColor: state.isFocused
+                ? "var(--primary, #423D89)"
+                : "var(--primary_50, #423D8980)",
+              padding: "0.05rem 0.2rem ",
+              color: "var(--primary, #423D89)",
+              maxHeight: "41px",
+              overflow: "auto",
+            }),
+          }}
+          options={selectOptions}
+          isMulti={false}
+          defaultValue={selection}
+          isClearable
+          onChange={(
+            selOptions: SingleValue<{ value: string; label: string }>,
+          ) => {
+            if (selOptions) {
+              setNewSelection({
+                id: selOptions.value,
+                name: selOptions.label,
+              } as T);
+            }
+            else {
+              setNewSelection(undefined);
+              setConsultant(undefined);
+            }
+          }}
+        />
+      ) : (
+        <p className="normal text-text_light_black">{newSelection?.name}</p>
+      )}
+    </td>
+  );
+}

--- a/frontend/src/components/consultants/FilteredConsultantsComp.tsx
+++ b/frontend/src/components/consultants/FilteredConsultantsComp.tsx
@@ -4,6 +4,7 @@ import {
   ConsultantReadModel,
   Degree,
   DepartmentReadModel,
+  DisciplineReadModel,
 } from "@/api-types";
 import { useSimpleConsultantsFilter } from "@/hooks/staffing/useConsultantsFilter";
 import Image from "next/image";
@@ -17,6 +18,7 @@ import { useParams } from "next/navigation";
 import EditableTableCompetencesCell from "./EditableTableCompetencesCell";
 import EditableTableDegreeCell from "./EditableTableDegreeCell";
 import EditableTableSelectGradYearCell from "./EditableTableSelectGradYearEdit";
+import EditableTableSingleSelectCell from "./EditableTableSingleSelectCell";
 import { isEqual } from "lodash";
 
 export default function FilteredConsultantsComp({
@@ -36,7 +38,7 @@ export default function FilteredConsultantsComp({
 
   const listRef = useRef<HTMLTableSectionElement>(null);
   const { setIsDisabledHotkeys } = useContext(FilteredContext);
-  const { competences, departments } = useContext(FilteredContext);
+  const { competences, departments, disciplines } = useContext(FilteredContext);
   const currentConsultantEditRef = useRef(selectedEditConsultant);
 
   useEffect(() => {
@@ -133,6 +135,12 @@ export default function FilteredConsultantsComp({
           <th className="min-w-[120px] md:min-w-[200px] py-1 pt-3">
             <div className="flex flex-col gap-1">
               <p className="normal text-left">Kompetanse</p>
+            </div>
+          </th>
+
+          <th className="py-1 pt-3 w-44">
+            <div className="flex flex-col gap-1">
+              <p className="normal text-left">Faggruppe</p>
             </div>
           </th>
 
@@ -285,6 +293,17 @@ export default function FilteredConsultantsComp({
                 }
                 competences={consultant.competences}
                 isEditing={selectedEditConsultant?.id === consultant.id}
+              />
+              <EditableTableSingleSelectCell
+                options={disciplines}
+                setConsultant={(discipline: DisciplineReadModel | undefined) =>
+                  setSelectedEditConsultant((selectedConsultant) => {
+                    if (!selectedConsultant) return null;
+                    return { ...selectedConsultant, discipline };
+                  })
+                }
+                originalSelection={consultant.discipline}
+                isEditing={selectedEditConsultant?.id == consultant.id}
               />
               <EditableTableDegreeCell
                 setConsultant={(degree: Degree) =>
@@ -477,6 +496,17 @@ export default function FilteredConsultantsComp({
                 }
                 competences={consultant.competences}
                 isEditing={selectedEditConsultant?.id === consultant.id}
+              />
+              <EditableTableSingleSelectCell
+                options={disciplines}
+                setConsultant={(discipline: DisciplineReadModel | undefined) =>
+                  setSelectedEditConsultant((selectedConsultant) => {
+                    if (!selectedConsultant) return null;
+                    return { ...selectedConsultant, discipline };
+                  })
+                }
+                originalSelection={consultant.discipline}
+                isEditing={selectedEditConsultant?.id == consultant.id}
               />
               <EditableTableDegreeCell
                 setConsultant={(degree: Degree) =>

--- a/frontend/src/hooks/ConsultantFilterProvider.tsx
+++ b/frontend/src/hooks/ConsultantFilterProvider.tsx
@@ -5,6 +5,7 @@ import {
   DepartmentReadModel,
   CompetenceReadModel,
   EngagementPerCustomerReadModel,
+  DisciplineReadModel,
 } from "@/api-types";
 import React, { createContext, ReactNode, useEffect, useState } from "react";
 import { parseYearWeekFromUrlString, weekToString } from "@/data/urlUtils";
@@ -28,6 +29,7 @@ export type FilterContextType = {
   setConsultants: React.Dispatch<React.SetStateAction<ConsultantReadModel[]>>;
   departments: DepartmentReadModel[];
   competences: CompetenceReadModel[];
+  disciplines: DisciplineReadModel[];
   customers: EngagementPerCustomerReadModel[];
   isDisabledHotkeys: boolean;
   setIsDisabledHotkeys: React.Dispatch<React.SetStateAction<boolean>>;
@@ -40,6 +42,7 @@ export const FilteredContext = createContext<FilterContextType>({
   setConsultants: () => null,
   departments: [],
   competences: [],
+  disciplines: [],
   customers: [],
   isDisabledHotkeys: false,
   setIsDisabledHotkeys: () => {},
@@ -51,6 +54,7 @@ export function ConsultantFilterProvider(props: {
   consultants: ConsultantReadModel[];
   departments: DepartmentReadModel[];
   competences: CompetenceReadModel[];
+  disciplines: DisciplineReadModel[];
   customers: EngagementPerCustomerReadModel[];
   children: ReactNode;
 }) {


### PR DESCRIPTION
- Implementing a reusable single-select table cell component `EditableTableSingleSelectCell`
- Adding type `DisciplineReadModel`
- Adding collection parameter `disciplines` to `ConsultantFilterProvider`
- Adding editable column _Faggrupper_ to the consultant overview