### PR TITLE
Adding Month class, and using the term 'month' with more consistency

### DIFF
--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -23,7 +23,7 @@ public record DetailedBookingForMonth(BookingDetails BookingDetails, List<Monthl
 	public double TotalHoursForMonth(Month month)
 	{
 		return Hours
-			.Where(hoursPerMonth => hoursPerMonth.Month.EqualsMonth(month))
+			.Where(hoursPerMonth => hoursPerMonth.Month.Equals(month))
 			.Sum(hoursInMonth => hoursInMonth.Hours);
 	}
 
@@ -78,7 +78,7 @@ public record ForecastForMonth(
 			.SingleOrDefault(f => f.Month.EqualsMonth(month))?
 			.AdjustedValue ?? 0;
 
-		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.EqualsMonth(month))?.BookingModel;
+		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.Equals(month))?.BookingModel;
 
 		if (booking == null)
 		{

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -50,7 +50,7 @@ public record struct MonthlyHours(Month Month, double Hours)
 {
 	public static MonthlyHours For(Month month, List<Staffing> staffings, Consultant consultant)
 	{
-		var staffedHoursInMonth = month.GetWeeksInMonth()
+		var staffedHoursInMonth = month.GetWeeks()
 			.Sum(week => MonthlyHoursHelper.GetStaffedHoursForMonthInWeek(month, week, staffings, consultant));
 
 		return new MonthlyHours(month, staffedHoursInMonth);
@@ -58,7 +58,7 @@ public record struct MonthlyHours(Month Month, double Hours)
 
 	public static MonthlyHours For(Month month, List<PlannedAbsence> plannedAbsences, Consultant consultant)
 	{
-		var absenceHoursInMonth = month.GetWeeksInMonth()
+		var absenceHoursInMonth = month.GetWeeks()
 			.Sum(week => MonthlyHoursHelper.GetPlannedAbsenceHoursForMonthInWeek(month, week, plannedAbsences, consultant));
 
 		return new MonthlyHours(month, absenceHoursInMonth);

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -85,7 +85,7 @@ public record ForecastForMonth(
 	public static ForecastForMonth GetFor(Consultant consultant, Month month, IEnumerable<BookedHoursInMonth> bookingSummary)
 	{
 		var manuallySetPercentage = consultant.Forecasts
-			.SingleOrDefault(f => f.Month.EqualsMonth(month))?
+			.SingleOrDefault(f => f.Month.Equals(month))?
 			.AdjustedValue ?? 0;
 
 		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.Equals(month))?.BookingModel;

--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -66,12 +66,22 @@ public record struct MonthlyHours(Month Month, double Hours)
 }
 
 public record ForecastForMonth(
-	Month Month,
+	DateOnly Month,
 	double BillableHours,
 	double SalariedHours,
 	int BillablePercentage,
 	int DisplayedPercentage)
 {
+	private ForecastForMonth(
+		Month month,
+		double billableHours,
+		double salariedHours,
+		int billablePercentage,
+		int displayedPercentage)
+		: this(month.FirstDay, billableHours, salariedHours, billablePercentage, displayedPercentage)
+	{
+	}
+
 	public static ForecastForMonth GetFor(Consultant consultant, Month month, IEnumerable<BookedHoursInMonth> bookingSummary)
 	{
 		var manuallySetPercentage = consultant.Forecasts

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -71,8 +71,8 @@ public static class ConsultantWithForecastFactory
 				Hours: vacationHoursPerMonth));
 		}
 
-		var firstWorkDayInScope = fromMonth.FirstWeekdayInMonth();
-		var firstWorkDayOutOfScope = firstExcludedMonth.FirstWeekdayInMonth();
+		var firstWorkDayInScope = fromMonth.FirstWeekday;
+		var firstWorkDayOutOfScope = firstExcludedMonth.FirstWeekday;
 
 		if (consultant.StartDate > firstWorkDayInScope)
 		{

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -12,10 +12,8 @@ namespace Api.Forecasts;
 
 public static class ConsultantWithForecastFactory
 {
-	public static List<ConsultantWithForecast> CreateMultiple(List<Consultant> consultants, Month fromMonth, int monthCount)
+	public static List<ConsultantWithForecast> CreateMultiple(List<Consultant> consultants, Month fromMonth, Month throughMonth)
 	{
-		var throughMonth = fromMonth.AddMonths(monthCount - 1);
-
 		return consultants
 			.Where(c => c.EndDate == null || c.EndDate > fromMonth.FirstDay)
 			.Where(c => c.StartDate == null || c.StartDate <= throughMonth.LastDay)

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -21,8 +21,10 @@ public static class ConsultantWithForecastFactory
 			.ToList();
 	}
 
-	public static ConsultantWithForecast CreateSingle(Consultant consultant, Month month)
+	public static ConsultantWithForecast CreateSingle(Consultant consultant, DateOnly forecastMonth)
 	{
+		var month = new Month(forecastMonth);
+
 		return CreateSingle(consultant, fromMonth: month, throughMonth: month);
 	}
 

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -21,10 +21,8 @@ public static class ConsultantWithForecastFactory
 			.ToList();
 	}
 
-	public static ConsultantWithForecast CreateSingle(Consultant consultant, DateOnly forecastMonth)
+	public static ConsultantWithForecast CreateSingle(Consultant consultant, Month month)
 	{
-		var month = new Month(forecastMonth);
-
 		return CreateSingle(consultant, fromMonth: month, throughMonth: month);
 	}
 

--- a/backend/Api/Forecasts/ForecastController.cs
+++ b/backend/Api/Forecasts/ForecastController.cs
@@ -43,10 +43,11 @@ public class ForecastController(
             $"GET FORECAST - [Checkpoint 5] Add relational data completed - {stopwatch.ElapsedMilliseconds} ms");
         var date = requestedDate ?? DateOnly.FromDateTime(DateTime.Today);
 
-        var firstMonthInQuarter = date.FirstMonthInQuarter();
+        var fromMonth = date.FirstMonthInQuarter();
+        var throughMonth = fromMonth.SkipAhead(monthCount - 1);
 
         var consultantsWithForecast =
-            ConsultantWithForecastFactory.CreateMultiple(consultants, firstMonthInQuarter, monthCount);
+            ConsultantWithForecastFactory.CreateMultiple(consultants, fromMonth, throughMonth);
         Console.WriteLine($"GET FORECAST - [Checkpoint 6] Created forecast data - {stopwatch.ElapsedMilliseconds} ms");
         stopwatch.Stop();
         return Ok(consultantsWithForecast);

--- a/backend/Api/Forecasts/ForecastController.cs
+++ b/backend/Api/Forecasts/ForecastController.cs
@@ -4,7 +4,6 @@ using Api.Helpers;
 using Core.Consultants;
 using Core.Extensions;
 using Core.Forecasts;
-using Core.Months;
 using Core.PlannedAbsences;
 using Core.Staffings;
 using Core.Weeks;
@@ -71,7 +70,7 @@ public class ForecastController(
 
         consultant = await AddRelationalDataToConsultant(consultant, cancellationToken);
 
-        var withForecast = ConsultantWithForecastFactory.CreateSingle(consultant, forecastWriteModel.Month);
+        var withForecast = ConsultantWithForecastFactory.CreateSingle(consultant, forecastWriteModel.DateOnly);
 
         var billablePercentage = withForecast.Forecasts[0].BillablePercentage;
 
@@ -158,9 +157,9 @@ public class ForecastController(
 
 public record ForecastWriteModel(
     int ConsultantId,
-    Month Month,
+    DateTime Month,
     int AdjustedValue
 )
 {
-    public DateOnly DateOnly => Month.FirstDay;
+    public DateOnly DateOnly => new(Month.Year, Month.Month, 1);
 }

--- a/backend/Api/Forecasts/ForecastController.cs
+++ b/backend/Api/Forecasts/ForecastController.cs
@@ -70,8 +70,7 @@ public class ForecastController(
 
         consultant = await AddRelationalDataToConsultant(consultant, cancellationToken);
 
-        var withForecast = ConsultantWithForecastFactory.CreateSingle(consultant, forecastWriteModel.Month,
-            forecastWriteModel.Month.GetNext());
+        var withForecast = ConsultantWithForecastFactory.CreateSingle(consultant, forecastWriteModel.Month);
 
         var billablePercentage = withForecast.Forecasts[0].BillablePercentage;
 

--- a/backend/Api/Forecasts/ForecastController.cs
+++ b/backend/Api/Forecasts/ForecastController.cs
@@ -4,6 +4,7 @@ using Api.Helpers;
 using Core.Consultants;
 using Core.Extensions;
 using Core.Forecasts;
+using Core.Months;
 using Core.PlannedAbsences;
 using Core.Staffings;
 using Core.Weeks;
@@ -42,10 +43,10 @@ public class ForecastController(
             $"GET FORECAST - [Checkpoint 5] Add relational data completed - {stopwatch.ElapsedMilliseconds} ms");
         var date = requestedDate ?? DateOnly.FromDateTime(DateTime.Today);
 
-        var firstDayInQuarter = date.FirstDayInQuarter();
+        var firstMonthInQuarter = date.FirstMonthInQuarter();
 
         var consultantsWithForecast =
-            ConsultantWithForecastFactory.CreateMultiple(consultants, firstDayInQuarter, monthCount);
+            ConsultantWithForecastFactory.CreateMultiple(consultants, firstMonthInQuarter, monthCount);
         Console.WriteLine($"GET FORECAST - [Checkpoint 6] Created forecast data - {stopwatch.ElapsedMilliseconds} ms");
         stopwatch.Stop();
         return Ok(consultantsWithForecast);
@@ -69,8 +70,8 @@ public class ForecastController(
 
         consultant = await AddRelationalDataToConsultant(consultant, cancellationToken);
 
-        var withForecast = ConsultantWithForecastFactory.CreateSingle(consultant, forecastWriteModel.DateOnly,
-            forecastWriteModel.DateOnly.AddMonths(1));
+        var withForecast = ConsultantWithForecastFactory.CreateSingle(consultant, forecastWriteModel.Month,
+            forecastWriteModel.Month.GetNext());
 
         var billablePercentage = withForecast.Forecasts[0].BillablePercentage;
 
@@ -157,9 +158,9 @@ public class ForecastController(
 
 public record ForecastWriteModel(
     int ConsultantId,
-    DateTime Month,
+    Month Month,
     int AdjustedValue
 )
 {
-    public DateOnly DateOnly => new(Month.Year, Month.Month, 1);
+    public DateOnly DateOnly => Month.FirstDay;
 }

--- a/backend/Api/Helpers/MonthlyHoursHelper.cs
+++ b/backend/Api/Helpers/MonthlyHoursHelper.cs
@@ -1,5 +1,6 @@
 using Core.Consultants;
 using Core.Extensions;
+using Core.Months;
 using Core.PlannedAbsences;
 using Core.Staffings;
 using Core.Weeks;
@@ -8,7 +9,7 @@ namespace Api.Helpers;
 
 public static class MonthlyHoursHelper
 {
-	public static double GetStaffedHoursForMonthInWeek(DateOnly month, Week week, List<Staffing> staffings, Consultant consultant)
+	public static double GetStaffedHoursForMonthInWeek(Month month, Week week, List<Staffing> staffings, Consultant consultant)
 	{
 		var staffedHoursInWeek = staffings
 			.Where(staffing => staffing.Week.Equals(week))
@@ -17,7 +18,7 @@ public static class MonthlyHoursHelper
 		return GetBookedHoursInWeekWithinMonth(month, week, staffedHoursInWeek, consultant);
 	}
 
-	public static double GetPlannedAbsenceHoursForMonthInWeek(DateOnly month, Week week, List<PlannedAbsence> plannedAbsences, Consultant consultant)
+	public static double GetPlannedAbsenceHoursForMonthInWeek(Month month, Week week, List<PlannedAbsence> plannedAbsences, Consultant consultant)
 	{
 		var absenceHoursInWeek = plannedAbsences
 			.Where(absence => absence.Week.Equals(week))
@@ -26,7 +27,7 @@ public static class MonthlyHoursHelper
 		return GetBookedHoursInWeekWithinMonth(month, week, absenceHoursInWeek, consultant);
 	}
 
-	private static double GetBookedHoursInWeekWithinMonth(DateOnly month, Week week, double bookedHoursInWeek, Consultant consultant)
+	private static double GetBookedHoursInWeekWithinMonth(Month month, Week week, double bookedHoursInWeek, Consultant consultant)
 	{
 		if (bookedHoursInWeek.IsEqualTo(0))
 		{
@@ -72,13 +73,13 @@ public static class MonthlyHoursHelper
 		return bookedHoursInWeek * (bookableHours.InWeekWithinMonth / bookableHours.InWeek);
 	}
 
-	private static bool WholeWorkWeekIsInMonth(DateOnly month, Week week)
+	private static bool WholeWorkWeekIsInMonth(Month month, Week week)
 	{
 		return week.FirstDayOfWorkWeek().EqualsMonth(month) &&
 			   week.LastWorkDayOfWeek().EqualsMonth(month);
 	}
 
-	private static (double InWeek, double InWeekWithinMonth, double InWeekWithinOtherMonth) GetBookableHours(DateOnly month, Week week, Consultant consultant)
+	private static (double InWeek, double InWeekWithinMonth, double InWeekWithinOtherMonth) GetBookableHours(Month month, Week week, Consultant consultant)
 	{
 		var organization = consultant.Department.Organization;
 

--- a/backend/Api/Helpers/WorkloadHelper.cs
+++ b/backend/Api/Helpers/WorkloadHelper.cs
@@ -54,7 +54,7 @@ public static class WorkloadHelper
 		var weekdayHolidaysInMonth = organization.GetHolidaysInMonth(month)
 			.Count(DateOnlyExtensions.IsWeekday);
 
-		return month.CountWeekdaysInMonth() - weekdayHolidaysInMonth;
+		return month.CountWeekdays() - weekdayHolidaysInMonth;
 	}
 
 	private static int CalculateWorkdaysInMonthWithinTimeSpan(Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan, Organization organization)
@@ -62,7 +62,7 @@ public static class WorkloadHelper
 		var fromDate = DateOnlyExtensions.Max(month.FirstDay, firstDayInTimeSpan);
 		var toDateInclusive = DateOnlyExtensions.Min(month.LastDay, lastDayInTimeSpan);
 
-		var weekdays = month.GetWeekdaysInMonth()
+		var weekdays = month.GetWeekdays()
 			.CountDaysInTimeSpan(fromDate, toDateInclusive);
 
 		var weekdayHolidays = organization.GetHolidaysInMonth(month)

--- a/backend/Api/Helpers/WorkloadHelper.cs
+++ b/backend/Api/Helpers/WorkloadHelper.cs
@@ -9,7 +9,7 @@ public static class WorkloadHelper
 {
 	public static List<MonthlyHours> CalculateMonthlyWorkHoursBefore(DateOnly date, List<Month> months, Organization organization)
 	{
-		var fromDate = months.Min().FirstWeekdayInMonth();
+		var fromDate = months.Min().FirstWeekday;
 
 		return CalculateMonthlyWorkHours(fromDate, toDateExclusive: date, organization);
 	}
@@ -17,7 +17,7 @@ public static class WorkloadHelper
 	public static List<MonthlyHours> CalculateMonthlyWorkHoursAfter(DateOnly date, List<Month> months, Organization organization)
 	{
 		var fromDate = date.AddDays(1);
-		var toDateExclusive = months.Max().AddMonths(1).FirstDayInMonth();
+		var toDateExclusive = months.Max().GetNext().FirstDay;
 
 		return CalculateMonthlyWorkHours(fromDate, toDateExclusive, organization);
 	}
@@ -59,8 +59,8 @@ public static class WorkloadHelper
 
 	private static int CalculateWorkdaysInMonthWithinTimeSpan(Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan, Organization organization)
 	{
-		var fromDate = DateOnlyExtensions.Max(month.FirstDayInMonth(), firstDayInTimeSpan);
-		var toDateInclusive = DateOnlyExtensions.Min(month.LastDayInMonth(), lastDayInTimeSpan);
+		var fromDate = DateOnlyExtensions.Max(month.FirstDay, firstDayInTimeSpan);
+		var toDateInclusive = DateOnlyExtensions.Min(month.LastDay, lastDayInTimeSpan);
 
 		var weekdays = month.GetWeekdaysInMonth()
 			.CountDaysInTimeSpan(fromDate, toDateInclusive);

--- a/backend/Api/Helpers/WorkloadHelper.cs
+++ b/backend/Api/Helpers/WorkloadHelper.cs
@@ -9,7 +9,9 @@ public static class WorkloadHelper
 {
 	public static List<MonthlyHours> CalculateMonthlyWorkHoursBefore(DateOnly date, List<Month> months, Organization organization)
 	{
-		var fromDate = months.Min().FirstWeekday;
+		if (months.Count == 0) return [];
+
+		var fromDate = months.Min()!.FirstWeekday;
 		var throughDate = date.AddDays(-1);
 
 		return CalculateMonthlyWorkHours(fromDate, throughDate, organization);
@@ -17,8 +19,10 @@ public static class WorkloadHelper
 
 	public static List<MonthlyHours> CalculateMonthlyWorkHoursAfter(DateOnly date, List<Month> months, Organization organization)
 	{
+		if (months.Count == 0) return [];
+
 		var fromDate = date.AddDays(1);
-		var throughDate = months.Max().LastDay;
+		var throughDate = months.Max()!.LastDay;
 
 		return CalculateMonthlyWorkHours(fromDate, throughDate, organization);
 	}

--- a/backend/Api/Helpers/WorkloadHelper.cs
+++ b/backend/Api/Helpers/WorkloadHelper.cs
@@ -1,19 +1,20 @@
 using Api.Forecasts;
 using Core.Extensions;
+using Core.Months;
 using Core.Organizations;
 
 namespace Api.Helpers;
 
 public static class WorkloadHelper
 {
-	public static List<MonthlyHours> CalculateMonthlyWorkHoursBefore(DateOnly date, List<DateOnly> months, Organization organization)
+	public static List<MonthlyHours> CalculateMonthlyWorkHoursBefore(DateOnly date, List<Month> months, Organization organization)
 	{
 		var fromDate = months.Min().FirstWeekdayInMonth();
 
 		return CalculateMonthlyWorkHours(fromDate, toDateExclusive: date, organization);
 	}
 
-	public static List<MonthlyHours> CalculateMonthlyWorkHoursAfter(DateOnly date, List<DateOnly> months, Organization organization)
+	public static List<MonthlyHours> CalculateMonthlyWorkHoursAfter(DateOnly date, List<Month> months, Organization organization)
 	{
 		var fromDate = date.AddDays(1);
 		var toDateExclusive = months.Max().AddMonths(1).FirstDayInMonth();
@@ -37,7 +38,7 @@ public static class WorkloadHelper
 			.ToList();
 	}
 
-	private static MonthlyHours CalculateWorkHoursForMonthInTimeSpan(DateOnly month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan, Organization organization)
+	private static MonthlyHours CalculateWorkHoursForMonthInTimeSpan(Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan, Organization organization)
 	{
 		var workdays = month.WholeMonthIsIncludedInTimeSpan(firstDayInTimeSpan, lastDayInTimeSpan)
 			? CalculateWorkdaysInMonth(month, organization)
@@ -48,7 +49,7 @@ public static class WorkloadHelper
 		return new MonthlyHours(month, workHours);
 	}
 
-	private static double CalculateWorkdaysInMonth(DateOnly month, Organization organization)
+	private static double CalculateWorkdaysInMonth(Month month, Organization organization)
 	{
 		var weekdayHolidaysInMonth = organization.GetHolidaysInMonth(month)
 			.Count(DateOnlyExtensions.IsWeekday);
@@ -56,7 +57,7 @@ public static class WorkloadHelper
 		return month.CountWeekdaysInMonth() - weekdayHolidaysInMonth;
 	}
 
-	private static int CalculateWorkdaysInMonthWithinTimeSpan(DateOnly month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan, Organization organization)
+	private static int CalculateWorkdaysInMonthWithinTimeSpan(Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan, Organization organization)
 	{
 		var fromDate = DateOnlyExtensions.Max(month.FirstDayInMonth(), firstDayInTimeSpan);
 		var toDateInclusive = DateOnlyExtensions.Min(month.LastDayInMonth(), lastDayInTimeSpan);

--- a/backend/Core/Extensions/DateOnlyExtensions.cs
+++ b/backend/Core/Extensions/DateOnlyExtensions.cs
@@ -39,24 +39,33 @@ public static class DateOnlyExtensions
 		return date.Year == month.Year && date.Month == month.MonthIndex;
 	}
 
-	public static IEnumerable<Month> GetMonthsUntil(this DateOnly fromDate, DateOnly untilDate)
+	/// <summary>
+	/// Returns a Month object for each month between and including fromDate and throughDate
+	/// </summary>
+	public static IEnumerable<Month> GetMonthsThrough(this DateOnly fromDate, DateOnly throughDate)
 	{
 		var fromMonth = new Month(fromDate);
-		var untilMonth = new Month(untilDate);
+		var throughMonth = new Month(throughDate);
 
-		return fromMonth.GetMonthsUntil(untilMonth);
+		return fromMonth.GetMonthsThrough(throughMonth);
 	}
 
-	public static IEnumerable<Week> GetWeeksThrough(this DateOnly fromDate, DateOnly lastIncludedDate)
+	/// <summary>
+	/// Returns a Week object for each week between and including fromDate and throughDate
+	/// </summary>
+	public static IEnumerable<Week> GetWeeksThrough(this DateOnly fromDate, DateOnly throughDate)
 	{
 		var firstWeek = Week.FromDateOnly(fromDate);
-		var lastWeek = Week.FromDateOnly(lastIncludedDate);
+		var lastWeek = Week.FromDateOnly(throughDate);
 
 		return firstWeek.GetNextWeeks(lastWeek);
 	}
 
-	public static int CountDaysInTimeSpan(this IEnumerable<DateOnly> days, DateOnly fromDate, DateOnly toDateInclusive)
+	/// <summary>
+	/// Returns the number of days between and including fromDate and throughDate
+	/// </summary>
+	public static int CountDaysInTimeSpan(this IEnumerable<DateOnly> days, DateOnly fromDate, DateOnly throughDate)
 	{
-		return days.Count(day => day >= fromDate && day <= toDateInclusive);
+		return days.Count(day => day >= fromDate && day <= throughDate);
 	}
 }

--- a/backend/Core/Extensions/DateOnlyExtensions.cs
+++ b/backend/Core/Extensions/DateOnlyExtensions.cs
@@ -17,29 +17,11 @@ public static class DateOnlyExtensions
 
 	public static bool IsWeekday(this DateOnly date) => date.DayOfWeek is >= DayOfWeek.Monday and <= DayOfWeek.Friday;
 
-	public static int CountWeekdaysInMonth(this Month month) => GetWeekdaysInMonth(month).Count();
-
 	public static Month FirstMonthInQuarter(this DateOnly date)
 	{
 		var firstMonthInQuarter = QuarterlyMonths.Where(month => date.Month >= month).Max();
 
 		return new Month(date.Year, firstMonthInQuarter);
-	}
-
-	public static IEnumerable<DateOnly> GetWeekdaysInMonth(this Month month)
-	{
-		for (var date = month.FirstDay; date.EqualsMonth(month); date = date.AddDays(1))
-		{
-			if (date.IsWeekday())
-			{
-				yield return date;
-			}
-		}
-	}
-
-	public static IEnumerable<Week> GetWeeksInMonth(this Month month)
-	{
-		return month.FirstDay.GetWeeksThrough(month.LastDay);
 	}
 
 	public static DateOnly Min(DateOnly date, DateOnly other)
@@ -62,48 +44,15 @@ public static class DateOnlyExtensions
 		var fromMonth = new Month(fromDate);
 		var untilMonth = new Month(untilDate);
 
-		return GetMonthsUntil(fromMonth, untilMonth);
+		return fromMonth.GetMonthsUntil(untilMonth);
 	}
 
-	public static IEnumerable<Month> GetMonthsUntil(this Month fromMonth, Month untilMonth)
-	{
-		if (untilMonth <= fromMonth)
-		{
-			yield break;
-		}
-
-		for (var month = fromMonth; month < untilMonth; month = month.GetNext())
-		{
-			yield return month;
-		}
-	}
-
-	private static IEnumerable<Week> GetWeeksThrough(this DateOnly fromDate, DateOnly lastIncludedDate)
+	public static IEnumerable<Week> GetWeeksThrough(this DateOnly fromDate, DateOnly lastIncludedDate)
 	{
 		var firstWeek = Week.FromDateOnly(fromDate);
 		var lastWeek = Week.FromDateOnly(lastIncludedDate);
 
 		return firstWeek.GetNextWeeks(lastWeek);
-	}
-
-	public static IEnumerable<Week> GetWeeksThrough(this Month fromMonth, Month throughMonth)
-	{
-		return GetWeeksThrough(fromMonth.FirstDay, throughMonth.LastDay);
-	}
-
-	public static bool WholeMonthIsIncludedInTimeSpan(this Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan)
-	{
-		if (month.FirstDay < firstDayInTimeSpan)
-		{
-			return false;
-		}
-
-		if (lastDayInTimeSpan < month.LastDay)
-		{
-			return false;
-		}
-
-		return true;
 	}
 
 	public static int CountDaysInTimeSpan(this IEnumerable<DateOnly> days, DateOnly fromDate, DateOnly toDateInclusive)

--- a/backend/Core/Extensions/DateOnlyExtensions.cs
+++ b/backend/Core/Extensions/DateOnlyExtensions.cs
@@ -19,33 +19,6 @@ public static class DateOnlyExtensions
 
 	public static int CountWeekdaysInMonth(this Month month) => GetWeekdaysInMonth(month).Count();
 
-	public static DateOnly FirstDayInMonth(this DateOnly month)
-	{
-		if (month.Day == 1)
-		{
-			return month;
-		}
-
-		return new DateOnly(month.Year, month.Month, 1);
-	}
-
-	public static DateOnly LastDayInMonth(this DateOnly month)
-	{
-		return month.FirstDayInMonth().AddMonths(1).AddDays(-1);
-	}
-
-	public static DateOnly FirstWeekdayInMonth(this DateOnly month)
-	{
-		var firstDayInMonth = month.FirstDayInMonth();
-
-		return firstDayInMonth.DayOfWeek switch
-		{
-			DayOfWeek.Saturday => firstDayInMonth.AddDays(2),
-			DayOfWeek.Sunday => firstDayInMonth.AddDays(1),
-			_ => firstDayInMonth,
-		};
-	}
-
 	public static Month FirstMonthInQuarter(this DateOnly date)
 	{
 		var firstMonthInQuarter = QuarterlyMonths.Where(month => date.Month >= month).Max();
@@ -55,7 +28,7 @@ public static class DateOnlyExtensions
 
 	public static IEnumerable<DateOnly> GetWeekdaysInMonth(this Month month)
 	{
-		for (var date = month.FirstDayInMonth(); date.EqualsMonth(month); date = date.AddDays(1))
+		for (var date = month.FirstDay; date.EqualsMonth(month); date = date.AddDays(1))
 		{
 			if (date.IsWeekday())
 			{
@@ -66,7 +39,7 @@ public static class DateOnlyExtensions
 
 	public static IEnumerable<Week> GetWeeksInMonth(this Month month)
 	{
-		return month.FirstDayInMonth().GetWeeksThrough(month.LastDayInMonth());
+		return month.FirstDay.GetWeeksThrough(month.LastDay);
 	}
 
 	public static DateOnly Min(DateOnly date, DateOnly other)
@@ -77,11 +50,6 @@ public static class DateOnlyExtensions
 	public static DateOnly Max(DateOnly date, DateOnly other)
 	{
 		return date > other ? date : other;
-	}
-
-	public static bool EqualsMonth(this DateOnly month, DateOnly other)
-	{
-		return month.Year == other.Year && month.Month == other.Month;
 	}
 
 	public static bool EqualsMonth(this DateOnly date, Month month)
@@ -125,12 +93,12 @@ public static class DateOnlyExtensions
 
 	public static bool WholeMonthIsIncludedInTimeSpan(this Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan)
 	{
-		if (month.FirstDayInMonth() < firstDayInTimeSpan)
+		if (month.FirstDay < firstDayInTimeSpan)
 		{
 			return false;
 		}
 
-		if (lastDayInTimeSpan < month.LastDayInMonth())
+		if (lastDayInTimeSpan < month.LastDay)
 		{
 			return false;
 		}

--- a/backend/Core/Extensions/DateOnlyExtensions.cs
+++ b/backend/Core/Extensions/DateOnlyExtensions.cs
@@ -36,7 +36,7 @@ public static class DateOnlyExtensions
 
 	public static bool EqualsMonth(this DateOnly date, Month month)
 	{
-		return date.Year == month.Year && date.Month == month.MonthIndex;
+		return date.Year == month.Year && date.Month == month.MonthNumber;
 	}
 
 	/// <summary>

--- a/backend/Core/Extensions/MonthExtensions.cs
+++ b/backend/Core/Extensions/MonthExtensions.cs
@@ -1,0 +1,58 @@
+using Core.Months;
+using Core.Weeks;
+
+namespace Core.Extensions;
+
+public static class MonthExtensions
+{
+	public static int CountWeekdays(this Month month) => GetWeekdays(month).Count();
+
+	public static IEnumerable<DateOnly> GetWeekdays(this Month month)
+	{
+		for (var date = month.FirstDay; date.EqualsMonth(month); date = date.AddDays(1))
+		{
+			if (date.IsWeekday())
+			{
+				yield return date;
+			}
+		}
+	}
+
+	public static IEnumerable<Week> GetWeeks(this Month month)
+	{
+		return month.FirstDay.GetWeeksThrough(month.LastDay);
+	}
+
+	public static IEnumerable<Month> GetMonthsUntil(this Month fromMonth, Month untilMonth)
+	{
+		if (untilMonth <= fromMonth)
+		{
+			yield break;
+		}
+
+		for (var month = fromMonth; month < untilMonth; month = month.GetNext())
+		{
+			yield return month;
+		}
+	}
+
+	public static IEnumerable<Week> GetWeeksThrough(this Month fromMonth, Month throughMonth)
+	{
+		return fromMonth.FirstDay.GetWeeksThrough(throughMonth.LastDay);
+	}
+
+	public static bool WholeMonthIsIncludedInTimeSpan(this Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan)
+	{
+		if (month.FirstDay < firstDayInTimeSpan)
+		{
+			return false;
+		}
+
+		if (lastDayInTimeSpan < month.LastDay)
+		{
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/backend/Core/Extensions/MonthExtensions.cs
+++ b/backend/Core/Extensions/MonthExtensions.cs
@@ -18,29 +18,41 @@ public static class MonthExtensions
 		}
 	}
 
+	/// <summary>
+	/// Returns a Week object for each week (whole or partial) that coincide with the month
+	/// </summary>
 	public static IEnumerable<Week> GetWeeks(this Month month)
 	{
 		return month.FirstDay.GetWeeksThrough(month.LastDay);
 	}
 
-	public static IEnumerable<Month> GetMonthsUntil(this Month fromMonth, Month untilMonth)
+	/// <summary>
+	/// Returns a Month object for each month between and including fromMonth and throughMonth
+	/// </summary>
+	public static IEnumerable<Month> GetMonthsThrough(this Month fromMonth, Month throughMonth)
 	{
-		if (untilMonth <= fromMonth)
+		if (throughMonth < fromMonth)
 		{
 			yield break;
 		}
 
-		for (var month = fromMonth; month < untilMonth; month = month.GetNext())
+		for (var month = fromMonth; month <= throughMonth; month = month.GetNext())
 		{
 			yield return month;
 		}
 	}
 
+	/// <summary>
+	/// Returns a Week object for each week between and including fromMonth and throughMonth
+	/// </summary>
 	public static IEnumerable<Week> GetWeeksThrough(this Month fromMonth, Month throughMonth)
 	{
 		return fromMonth.FirstDay.GetWeeksThrough(throughMonth.LastDay);
 	}
 
+	/// <summary>
+	/// Returns true if the time span running from firstDayInTimeSpan to lastDayInTimeSpan (inclusive) covers all the days in the month
+	/// </summary>
 	public static bool WholeMonthIsIncludedInTimeSpan(this Month month, DateOnly firstDayInTimeSpan, DateOnly lastDayInTimeSpan)
 	{
 		if (month.FirstDay < firstDayInTimeSpan)

--- a/backend/Core/Forecasts/Forecast.cs
+++ b/backend/Core/Forecasts/Forecast.cs
@@ -1,8 +1,10 @@
+using Core.Months;
+
 namespace Core.Forecasts;
 
 public class Forecast
 {
     public required int ConsultantId { get; init; }
-    public required DateOnly Month { get; init; }
+    public required Month Month { get; init; }
     public int? AdjustedValue { get; set; }
 }

--- a/backend/Core/Forecasts/IForecastRepository.cs
+++ b/backend/Core/Forecasts/IForecastRepository.cs
@@ -1,3 +1,5 @@
+using Core.Months;
+
 namespace Core.Forecasts;
 
 public interface IForecastRepository
@@ -6,7 +8,7 @@ public interface IForecastRepository
 	///     Gets the forecast with the given keys
 	/// </summary>
 	/// <returns>A <see cref="Forecast" /> if it exists, else <pre>null</pre></returns>
-	public Task<Forecast?> GetForecast(int consultantId, DateOnly month, CancellationToken cancellationToken);
+	public Task<Forecast?> GetForecast(int consultantId, Month month, CancellationToken cancellationToken);
 	
 	/// <summary>
 	/// Gets the forecasts registered on the consultants with the given consultantId

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -16,7 +16,7 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 	private DateOnly? _lastWeekday;
 
 	public int Year { get; } = year;
-	public int MonthIndex { get; } = month;
+	public int MonthNumber { get; } = month;
 
 	public DateOnly FirstDay => GetFirstDay();
 	public DateOnly LastDay => GetLastDay();
@@ -25,7 +25,7 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 
 	private DateOnly GetFirstDay()
 	{
-		_firstDay ??= new DateOnly(Year, MonthIndex, 1);
+		_firstDay ??= new DateOnly(Year, MonthNumber, 1);
 
 		return _firstDay.Value;
 	}
@@ -90,7 +90,7 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 
 		if (Year == other.Year)
 		{
-			return MonthIndex - other.MonthIndex;
+			return MonthNumber - other.MonthNumber;
 		}
 
 		return Year - other.Year;
@@ -100,7 +100,7 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 	{
 		if (other is null) return false;
 
-		return Year == other.Year && MonthIndex == other.MonthIndex;
+		return Year == other.Year && MonthNumber == other.MonthNumber;
 	}
 
 	public override bool Equals(object? other)
@@ -115,34 +115,34 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 
 	public override int GetHashCode()
 	{
-		return HashCode.Combine(Year, MonthIndex);
+		return HashCode.Combine(Year, MonthNumber);
 	}
 
 	public static bool operator <(Month left, Month right)
 	{
 		if (left.Year < right.Year) return true;
 		if (left.Year > right.Year) return false;
-		return left.MonthIndex < right.MonthIndex;
+		return left.MonthNumber < right.MonthNumber;
 	}
 
 	public static bool operator >(Month left, Month right)
 	{
 		if (left.Year > right.Year) return true;
 		if (left.Year < right.Year) return false;
-		return left.MonthIndex > right.MonthIndex;
+		return left.MonthNumber > right.MonthNumber;
 	}
 
 	public static bool operator <=(Month left, Month right)
 	{
 		if (left.Year < right.Year) return true;
 		if (left.Year > right.Year) return false;
-		return left.MonthIndex <= right.MonthIndex;
+		return left.MonthNumber <= right.MonthNumber;
 	}
 
 	public static bool operator >=(Month left, Month right)
 	{
 		if (left.Year > right.Year) return true;
 		if (left.Year < right.Year) return false;
-		return left.MonthIndex >= right.MonthIndex;
+		return left.MonthNumber >= right.MonthNumber;
 	}
 }

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -1,0 +1,65 @@
+namespace Core.Months;
+
+public class Month(DateOnly date)
+{
+	private readonly int _year = date.Year;
+	private readonly int _month = date.Month;
+
+	private DateOnly? _firstDay;
+	private DateOnly? _lastDay;
+	private DateOnly? _firstWeekday { get; set; }
+	private DateOnly? _lastWeekday { get; set; }
+
+	public DateOnly FirstDay => GetFirstDay();
+	public DateOnly LastDay => GetLastDay();
+	public DateOnly FirstWeekday => GetFirstWeekday();
+	public DateOnly LastWeekday => GetLastWeekday();
+
+	private DateOnly GetFirstDay()
+	{
+		_firstDay ??= new DateOnly(_year, _month, 1);
+
+		return _firstDay.Value;
+	}
+
+	private DateOnly GetLastDay()
+	{
+		_lastDay ??= FirstDay.AddMonths(1).AddDays(-1);
+
+		return _lastDay.Value;
+	}
+
+	private DateOnly GetFirstWeekday()
+	{
+		_firstWeekday ??= CalculateFirstWeekday();
+
+		return _firstWeekday.Value;
+	}
+
+	private DateOnly GetLastWeekday()
+	{
+		_lastWeekday ??= CalculateLastWeekday();
+
+		return _lastWeekday.Value;
+	}
+
+	private DateOnly CalculateFirstWeekday()
+	{
+		return FirstDay.DayOfWeek switch
+		{
+			DayOfWeek.Saturday => FirstDay.AddDays(2),
+			DayOfWeek.Sunday => FirstDay.AddDays(1),
+			_ => FirstDay,
+		};
+	}
+
+	private DateOnly CalculateLastWeekday()
+	{
+		return LastDay.DayOfWeek switch
+		{
+			DayOfWeek.Sunday => LastDay.AddDays(-2),
+			DayOfWeek.Saturday => LastDay.AddDays(-1),
+			_ => LastDay,
+		};
+	}
+}

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -1,14 +1,18 @@
 namespace Core.Months;
 
-public class Month(DateOnly date)
+public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<Month>
 {
-	private readonly int _year = date.Year;
-	private readonly int _month = date.Month;
+	public Month(DateOnly date) : this(date.Year, date.Month)
+	{
+	}
 
 	private DateOnly? _firstDay;
 	private DateOnly? _lastDay;
 	private DateOnly? _firstWeekday { get; set; }
 	private DateOnly? _lastWeekday { get; set; }
+
+	public int Year { get; } = year;
+	public int MonthIndex { get; } = month;
 
 	public DateOnly FirstDay => GetFirstDay();
 	public DateOnly LastDay => GetLastDay();
@@ -17,7 +21,7 @@ public class Month(DateOnly date)
 
 	private DateOnly GetFirstDay()
 	{
-		_firstDay ??= new DateOnly(_year, _month, 1);
+		_firstDay ??= new DateOnly(Year, MonthIndex, 1);
 
 		return _firstDay.Value;
 	}
@@ -61,5 +65,89 @@ public class Month(DateOnly date)
 			DayOfWeek.Saturday => LastDay.AddDays(-1),
 			_ => LastDay,
 		};
+	}
+
+	public Month GetNext()
+	{
+		return new Month(FirstDay.AddMonths(1));
+	}
+
+	public Month AddMonths(int monthCount)
+	{
+		return new Month(FirstDay.AddMonths(monthCount));
+	}
+
+	#region Helper methods to remove
+
+	public DateOnly FirstDayInMonth() => FirstDay;
+	public DateOnly LastDayInMonth() => LastDay;
+	public DateOnly FirstWeekdayInMonth() => FirstWeekday;
+
+	public bool EqualsMonth(Month other) => Equals(other);
+	#endregion
+
+	public int CompareTo(Month? other)
+	{
+		if (other is null)
+		{
+			return 1;
+		}
+
+		if (Year == other.Year)
+		{
+			return MonthIndex - other.MonthIndex;
+		}
+
+		return Year - other.Year;
+	}
+
+	public bool Equals(Month? other)
+	{
+		if (other is null) return false;
+
+		return Year == other.Year && MonthIndex == other.MonthIndex;
+	}
+
+	public override bool Equals(object? other)
+	{
+		if (other is null)
+		{
+			return false;
+		}
+
+		return typeof(object) == typeof(Month) && EqualsMonth(other as Month);
+	}
+
+	public override int GetHashCode()
+	{
+		return HashCode.Combine(Year, MonthIndex);
+	}
+
+	public static bool operator <(Month left, Month right)
+	{
+		if (left.Year < right.Year) return true;
+		if (left.Year > right.Year) return false;
+		return left.MonthIndex < right.MonthIndex;
+	}
+
+	public static bool operator >(Month left, Month right)
+	{
+		if (left.Year > right.Year) return true;
+		if (left.Year < right.Year) return false;
+		return left.MonthIndex > right.MonthIndex;
+	}
+
+	public static bool operator <=(Month left, Month right)
+	{
+		if (left.Year < right.Year) return true;
+		if (left.Year > right.Year) return false;
+		return left.MonthIndex <= right.MonthIndex;
+	}
+
+	public static bool operator >=(Month left, Month right)
+	{
+		if (left.Year > right.Year) return true;
+		if (left.Year < right.Year) return false;
+		return left.MonthIndex >= right.MonthIndex;
 	}
 }

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -67,12 +67,12 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 		};
 	}
 
-	public Month GetNext()
-	{
-		return new Month(FirstDay.AddMonths(1));
-	}
+	public Month GetNext() => SkipAhead(1);
 
-	public Month AddMonths(int monthCount)
+	/// <summary>
+	/// Returns a Month object for the month coming monthCount months after this instance
+	/// </summary>
+	public Month SkipAhead(int monthCount)
 	{
 		return new Month(FirstDay.AddMonths(monthCount));
 	}

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -77,15 +77,6 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 		return new Month(FirstDay.AddMonths(monthCount));
 	}
 
-	#region Helper methods to remove
-
-	public DateOnly FirstDayInMonth() => FirstDay;
-	public DateOnly LastDayInMonth() => LastDay;
-	public DateOnly FirstWeekdayInMonth() => FirstWeekday;
-
-	public bool EqualsMonth(Month other) => Equals(other);
-	#endregion
-
 	public int CompareTo(Month? other)
 	{
 		if (other is null)
@@ -115,7 +106,7 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 			return false;
 		}
 
-		return typeof(object) == typeof(Month) && EqualsMonth(other as Month);
+		return typeof(object) == typeof(Month) && Equals(other as Month);
 	}
 
 	public override int GetHashCode()

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -8,8 +8,8 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 
 	private DateOnly? _firstDay;
 	private DateOnly? _lastDay;
-	private DateOnly? _firstWeekday { get; set; }
-	private DateOnly? _lastWeekday { get; set; }
+	private DateOnly? _firstWeekday;
+	private DateOnly? _lastWeekday;
 
 	public int Year { get; } = year;
 	public int MonthIndex { get; } = month;

--- a/backend/Core/Months/Month.cs
+++ b/backend/Core/Months/Month.cs
@@ -6,6 +6,10 @@ public sealed class Month(int year, int month) : IComparable<Month>, IEquatable<
 	{
 	}
 
+	public Month(DateTime date) : this(date.Year, date.Month)
+	{
+	}
+
 	private DateOnly? _firstDay;
 	private DateOnly? _lastDay;
 	private DateOnly? _firstWeekday;

--- a/backend/Core/Organizations/Organization.cs
+++ b/backend/Core/Organizations/Organization.cs
@@ -75,7 +75,7 @@ public class Organization
 
     public double GetTotalWeekdayHoursInMonth(Month month)
     {
-        return HoursPerWorkday * month.CountWeekdaysInMonth();
+        return HoursPerWorkday * month.CountWeekdays();
     }
 
     private bool IsHoliday(DateOnly day)

--- a/backend/Core/Organizations/Organization.cs
+++ b/backend/Core/Organizations/Organization.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Core.Absences;
 using Core.Customers;
 using Core.Extensions;
+using Core.Months;
 using Core.Weeks;
 using PublicHoliday;
 
@@ -48,7 +49,7 @@ public class Organization
     /// <summary>
     /// Returns the count of holidays that occur on a weekday (work day) within the given month
     /// </summary>
-    public int GetTotalHolidaysInMonth(DateOnly month)
+    public int GetTotalHolidaysInMonth(Month month)
     {
         return GetHolidaysInMonth(month).Count();
     }
@@ -56,7 +57,7 @@ public class Organization
     /// <summary>
     /// Returns all holidays that occur on a weekday (work day) within the given month
     /// </summary>
-    public IEnumerable<DateOnly> GetHolidaysInMonth(DateOnly month)
+    public IEnumerable<DateOnly> GetHolidaysInMonth(Month month)
     {
         return GetPublicHolidays(month.Year)
             .Where(holiday => holiday.EqualsMonth(month))
@@ -66,13 +67,13 @@ public class Organization
     /// <summary>
     /// Returns the total amount of hours for the holidays that occur on a weekday (work day) within the given month
     /// </summary>
-    public double GetTotalHolidayHoursInMonth(DateOnly month)
+    public double GetTotalHolidayHoursInMonth(Month month)
     {
         var holidayDays = GetTotalHolidaysInMonth(month);
         return holidayDays * HoursPerWorkday;
     }
 
-    public double GetTotalWeekdayHoursInMonth(DateOnly month)
+    public double GetTotalWeekdayHoursInMonth(Month month)
     {
         return HoursPerWorkday * month.CountWeekdaysInMonth();
     }

--- a/backend/Infrastructure/DatabaseContext/ApplicationContext.cs
+++ b/backend/Infrastructure/DatabaseContext/ApplicationContext.cs
@@ -6,6 +6,7 @@ using Core.Consultants.Disciplines;
 using Core.Customers;
 using Core.Engagements;
 using Core.Forecasts;
+using Core.Months;
 using Core.Organizations;
 using Core.PlannedAbsences;
 using Core.Staffings;
@@ -50,6 +51,10 @@ public class ApplicationContext(IOptions<InfrastructureConfig> config) : DbConte
         configurationBuilder
             .Properties<Week>()
             .HaveConversion<WeekConverter>();
+
+        configurationBuilder
+            .Properties<Month>()
+            .HaveConversion<MonthConverter>();
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/backend/Infrastructure/Migrations/20250430092147_Forecast_UseMonthDataTypeForMonthProperty.Designer.cs
+++ b/backend/Infrastructure/Migrations/20250430092147_Forecast_UseMonthDataTypeForMonthProperty.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20250430092147_Forecast_UseMonthDataTypeForMonthProperty")]
+    partial class Forecast_UseMonthDataTypeForMonthProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Infrastructure/Migrations/20250430092147_Forecast_UseMonthDataTypeForMonthProperty.cs
+++ b/backend/Infrastructure/Migrations/20250430092147_Forecast_UseMonthDataTypeForMonthProperty.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Forecast_UseMonthDataTypeForMonthProperty : Migration
+    {
+        private const string TableName = "Forecasts";
+        private const string PrimaryKeyName = "PK_Forecasts";
+        private const string ColumnName = "Month";
+        private const string ColumnNameTemp = "MonthTemporary";
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            DropPrimaryKey(migrationBuilder);
+            AddTemporaryIntColumn(migrationBuilder);
+            ReplaceColumn(migrationBuilder);
+            AddPrimaryKey(migrationBuilder);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            DropPrimaryKey(migrationBuilder);
+            AddTemporaryDateTimeColumn(migrationBuilder);
+            ReplaceColumn(migrationBuilder);
+            AddPrimaryKey(migrationBuilder);
+        }
+
+        private static void DropPrimaryKey(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: PrimaryKeyName,
+                table: TableName);
+        }
+
+        private static void AddTemporaryIntColumn(MigrationBuilder migrationBuilder)
+        {
+            // Add nullable column
+            migrationBuilder.AddColumn<int>(
+                name: ColumnNameTemp,
+                table: TableName,
+                type: "int",
+                nullable: true);
+
+            // Populate column with values
+            migrationBuilder.Sql($"UPDATE {TableName} SET {ColumnNameTemp} = 100 * DATEPART(yyyy, {ColumnName}) + DATEPART(MM, {ColumnName})");
+
+            // Make column not nullable
+            migrationBuilder.AlterColumn<int>(
+                name: ColumnNameTemp,
+                table: TableName,
+                nullable: false);
+        }
+
+        private static void AddTemporaryDateTimeColumn(MigrationBuilder migrationBuilder)
+        {
+            // Add nullable column
+            migrationBuilder.AddColumn<DateTime>(
+                name: ColumnNameTemp,
+                table: TableName,
+                type: "datetime2",
+                nullable: true);
+
+            // Populate column with values
+            migrationBuilder.Sql($"UPDATE {TableName} SET {ColumnNameTemp} = DATEFROMPARTS({ColumnName} / 100, {ColumnName} % 100, 1)");
+
+            // Make column not nullable
+            migrationBuilder.AlterColumn<DateTime>(
+                name: ColumnNameTemp,
+                table: TableName,
+                nullable: false);
+        }
+
+        private static void ReplaceColumn(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: ColumnName,
+                table: TableName);
+
+            migrationBuilder.RenameColumn(
+                name: ColumnNameTemp,
+                table: TableName,
+                newName: ColumnName);
+        }
+
+        private static void AddPrimaryKey(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddPrimaryKey(
+                name: PrimaryKeyName,
+                table: TableName,
+                columns: ["ConsultantId", "Month"]);
+        }
+    }
+}

--- a/backend/Infrastructure/Repositories/Forecasts/ForecastDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Forecasts/ForecastDbRepository.cs
@@ -11,7 +11,7 @@ public class ForecastDbRepository(ApplicationContext context) : IForecastReposit
     {
         return await context.Forecasts
             .AsNoTracking()
-            .FirstOrDefaultAsync(forecast => forecast.ConsultantId == consultantId && forecast.Month == month.FirstDay,
+            .FirstOrDefaultAsync(forecast => forecast.ConsultantId == consultantId && forecast.Month == month,
                 cancellationToken);
     }
 

--- a/backend/Infrastructure/Repositories/Forecasts/ForecastDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Forecasts/ForecastDbRepository.cs
@@ -1,4 +1,5 @@
 using Core.Forecasts;
+using Core.Months;
 using Infrastructure.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 
@@ -6,11 +7,11 @@ namespace Infrastructure.Repositories.Forecasts;
 
 public class ForecastDbRepository(ApplicationContext context) : IForecastRepository
 {
-    public async Task<Forecast?> GetForecast(int consultantId, DateOnly month, CancellationToken cancellationToken)
+    public async Task<Forecast?> GetForecast(int consultantId, Month month, CancellationToken cancellationToken)
     {
         return await context.Forecasts
             .AsNoTracking()
-            .FirstOrDefaultAsync(forecast => forecast.ConsultantId == consultantId && forecast.Month == month,
+            .FirstOrDefaultAsync(forecast => forecast.ConsultantId == consultantId && forecast.Month == month.FirstDay,
                 cancellationToken);
     }
 

--- a/backend/Infrastructure/Repositories/Forecasts/ForecastDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Forecasts/ForecastDbRepository.cs
@@ -47,7 +47,7 @@ public class ForecastDbRepository(ApplicationContext context) : IForecastReposit
             .ToArrayAsync(cancellationToken);
 
         var doesExist = forecasts.ToLookup(f =>
-            filteredForecasts.Any(k => k.ConsultantId == f.ConsultantId && k.Month == f.Month));
+            filteredForecasts.Any(k => k.ConsultantId == f.ConsultantId && k.Month.Equals(f.Month)));
 
         context.Forecasts.UpdateRange(doesExist[true]);
         context.Forecasts.AddRange(doesExist[false]);

--- a/backend/Infrastructure/ValueConverters/MonthConverter.cs
+++ b/backend/Infrastructure/ValueConverters/MonthConverter.cs
@@ -10,7 +10,7 @@ public class MonthConverter() : ValueConverter<Month, int>(
 	/// <summary>
 	/// Converts a Month object to an int with six digits: YYYYMM
 	/// </summary>
-	private static int ToSortableInt(Month month) => month.Year * 100 + month.MonthIndex;
+	private static int ToSortableInt(Month month) => month.Year * 100 + month.MonthNumber;
 
 	/// <summary>
 	/// Converts an int of six digits (YYYYMM) to a Month object

--- a/backend/Infrastructure/ValueConverters/MonthConverter.cs
+++ b/backend/Infrastructure/ValueConverters/MonthConverter.cs
@@ -1,0 +1,8 @@
+using Core.Months;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Infrastructure.ValueConverters;
+
+public class MonthConverter() : ValueConverter<Month, DateOnly>(
+	month => month.FirstDay,
+	monthAsDateOnly => new Month(monthAsDateOnly));

--- a/backend/Infrastructure/ValueConverters/MonthConverter.cs
+++ b/backend/Infrastructure/ValueConverters/MonthConverter.cs
@@ -3,6 +3,23 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Infrastructure.ValueConverters;
 
-public class MonthConverter() : ValueConverter<Month, DateOnly>(
-	month => month.FirstDay,
-	monthAsDateOnly => new Month(monthAsDateOnly));
+public class MonthConverter() : ValueConverter<Month, int>(
+	month => ToSortableInt(month),
+	monthAsInt => FromSortableInt(monthAsInt))
+{
+	/// <summary>
+	/// Converts a Month object to an int with six digits: YYYYMM
+	/// </summary>
+	private static int ToSortableInt(Month month) => month.Year * 100 + month.MonthIndex;
+
+	/// <summary>
+	/// Converts an int of six digits (YYYYMM) to a Month object
+	/// </summary>
+	private static Month FromSortableInt(int monthAsInt)
+	{
+		var year = monthAsInt / 100;
+		var monthIndex = monthAsInt % 100;
+
+		return new Month(year, monthIndex);
+	}
+}

--- a/backend/Tests/Api.E2E/ForecastRepositoryTests.cs
+++ b/backend/Tests/Api.E2E/ForecastRepositoryTests.cs
@@ -1,6 +1,7 @@
 using Bogus;
 using Core.Consultants;
 using Core.Forecasts;
+using Core.Months;
 using Core.Organizations;
 using Infrastructure.Repositories.Forecasts;
 using Microsoft.EntityFrameworkCore;
@@ -58,7 +59,7 @@ public class ForecastRepositoryTests(ApiFactory apiFactory) : TestsBase(apiFacto
         {
             ConsultantId = org.Departments[0].Consultants[0].Id,
             AdjustedValue = _faker.Random.Int(0, 90),
-            Month = new DateOnly(2025, _faker.Random.Int(1, 12), 1)
+            Month = new Month(2025, _faker.Random.Int(1, 12))
         };
     }
 


### PR DESCRIPTION
The two main goals are:
- to use the term _month_ with more consistency, especially with regards to timespans
- avoid having to fiddle with the _day of month_ part of `DateOnly` objects when it is irrelevant

Changes in this PR include:
- introducing class `Month`
- replacing datatype `DateOnly` with `Month` for objects that represent a month.
<mark>**Migration alert!**</mark> This includes a change in the `Forecast` class, which is used in the database. The migration file has been customized to include a safe calculation of the replaced column.
- adding an extra constructor for `ForecastForMonth`, which takes a `Month` object rather than a `DateOnly` object
- adding a class for `Month` extension methods
   - some existing `DateOnly` extension methods have been converted to `Month` extension methods and moved here
- using the term _through_ to indicate _to and including_ everywhere where a _Month_ object defines the end of a timespan.
Terms such as _until_, _exclusive_ and _incluisve_ have been replaced with _through_, and the associated logic has been adjusted when necessary.

The datatype of the `Month` properties in the records `ForecastForMonth` and `ForecastWriteModel` have _not_ been changed. These date objects are used for logic in the frontend, and do not need to change.
