### PR TITLE
fix: Make start of year default for forecast request date

### DIFF
--- a/backend/Api/Forecasts/ForecastController.cs
+++ b/backend/Api/Forecasts/ForecastController.cs
@@ -40,12 +40,10 @@ public class ForecastController(
         consultants = await AddRelationalDataToConsultant(consultants, cancellationToken);
         Console.WriteLine(
             $"GET FORECAST - [Checkpoint 5] Add relational data completed - {stopwatch.ElapsedMilliseconds} ms");
-        var date = requestedDate ?? DateOnly.FromDateTime(DateTime.Today);
-
-        var firstDayInQuarter = date.FirstDayInQuarter();
+        var date = requestedDate?.FirstDayInQuarter() ?? new DateOnly(DateTimeOffset.Now.Year, 1, 1);
 
         var consultantsWithForecast =
-            ConsultantWithForecastFactory.CreateMultiple(consultants, firstDayInQuarter, monthCount);
+            ConsultantWithForecastFactory.CreateMultiple(consultants, date, monthCount);
         Console.WriteLine($"GET FORECAST - [Checkpoint 6] Created forecast data - {stopwatch.ElapsedMilliseconds} ms");
         stopwatch.Stop();
         return Ok(consultantsWithForecast);


### PR DESCRIPTION
Etter overgang til nytt kvartal er Q1 borte fra prognosen: https://bemanning.variant.no/variant-norge/prognose

Jeg går ut ifra at det er fordi default er at en tar første dag i inneværende kvartal i backend. Har snakket med @oddsve som mente at det var mer naturlig å se året under ett som standard her.