### PR TITLE
Bugfix: Staffing for related consultants is not updated when an agreement has been added or removed

### DIFF
--- a/backend/Core/Agreements/IAgreementRepository.cs
+++ b/backend/Core/Agreements/IAgreementRepository.cs
@@ -6,6 +6,7 @@ public interface IAgreementsRepository
 
     public Task<List<Agreement>> GetAgreementsByEngagementId(int engagementId, CancellationToken cancellationToken);
     public Task<List<Agreement>> GetAgreementsByCustomerId(int customerId, CancellationToken cancellationToken);
+    public Task<List<int>> GetConsultantIdsRelatedToAgreementId(int agreementId, CancellationToken cancellationToken);
     public Task AddAgreementAsync(Agreement agreement, CancellationToken cancellationToken);
 
     public Task UpdateAgreementAsync(Agreement agreement, CancellationToken cancellationToken);

--- a/backend/Core/Extensions/MemoryCacheExtensions.cs
+++ b/backend/Core/Extensions/MemoryCacheExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Core.Extensions;
+
+public static class MemoryCacheExtensions
+{
+	public static void ClearConsultantCache(this IMemoryCache cache, string orgUrlKey)
+	{
+		cache.Remove(ConsultantCacheKey(orgUrlKey));
+	}
+
+	public static void ClearStaffingFor(this IMemoryCache cache, int consultantId)
+	{
+		cache.Remove(StaffingCacheKey(consultantId));
+	}
+
+	public static void ClearStaffingFor(this IMemoryCache cache, List<int> consultantIds)
+	{
+		foreach (var consultantId in consultantIds)
+		{
+			cache.ClearStaffingFor(consultantId);
+		}
+	}
+
+	private static string ConsultantCacheKey(string orgUrlKey) => $"consultantCacheKey/{orgUrlKey}";
+
+	private static string StaffingCacheKey(int consultantId) => $"StaffingCacheRepository/{consultantId}";
+}

--- a/backend/Infrastructure/Repositories/Agreement/AgreementDbRepository.cs
+++ b/backend/Infrastructure/Repositories/Agreement/AgreementDbRepository.cs
@@ -29,6 +29,21 @@ public class AgreementDbRepository(ApplicationContext context) : IAgreementsRepo
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<List<int>> GetConsultantIdsRelatedToAgreementId(int agreementId, CancellationToken cancellationToken)
+    {
+        var consultantIds = await context.Agreements
+            .Include(a => a.Engagement)
+            .ThenInclude(e => e!.Staffings)
+            .Where(a => a.Id == agreementId)
+            .Where(a => a.Engagement != null)
+            .SelectMany(a => a.Engagement!.Staffings)
+            .Select(s => s.ConsultantId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return consultantIds;
+    }
+
     public async Task AddAgreementAsync(Agreement agreement, CancellationToken cancellationToken)
     {
         context.Agreements.Add(agreement);


### PR DESCRIPTION
Case:
> When a consultant is booked on a project that does _not_ have an agreement attached to it, a red alert icon is displayed on the consultant row on the staffing page. Upon adding an agreement to the given project, that red alert icon should no longer be shown. Similarly, if a staffed project _does_ have an agreement, no red alert icon is displayed. Upon deleting that agreement, the red alert icon should become visible. **Adding or deleting an agreement does _not_ trigger these icon display changes.**

The reason that the displayed icons do not change is that staffing data is cached per consultant. Upon adding or deleting an agreement, the staffing cache was _not_ cleared. Hence, the cached agreement data was displayed even after adding/deleting the agreement.

To fix this, the staffing cache is now being cleared for each consultant that is/was staffed on the project to which the agreement is associated, whenever an agreement is added, updated or deleted.

The class `MemoryCacheExtensions` has also been added. The goal is to collect all cache-communicating methods there. This will be done in a separate branch/PR.

---

Note: The frontend caching may still cache the previously displayed data, so when opening the staffing page after having added/updated/deleted an agreement, you may need to refresh the page to see the icon change.