### PR TITLE
Adding class MemoryCacheExtensions, and collecting all cache-handling logic there

### DIFF
--- a/backend/Api/Common/IStorageService.cs
+++ b/backend/Api/Common/IStorageService.cs
@@ -10,7 +10,6 @@ namespace Api.Common;
 
 public interface IStorageService
 {
-    void ClearConsultantCache(string orgUrlKey);
     List<Consultant> LoadConsultants(string orgUrlKey);
     Consultant? LoadConsultantForSingleWeek(int consultantId, Week week);
     Consultant? LoadConsultantForWeekSet(int consultantId, List<Week> weeks);

--- a/backend/Api/StaffingController/StaffingController.cs
+++ b/backend/Api/StaffingController/StaffingController.cs
@@ -3,6 +3,7 @@ using Api.Common;
 using Api.Common.Types;
 using Api.Helpers;
 using Core.Consultants;
+using Core.Extensions;
 using Core.PlannedAbsences;
 using Core.Staffings;
 using Core.Weeks;
@@ -126,7 +127,7 @@ public class StaffingController(
                     await staffingRepository.UpsertStaffing(updatedStaffing, cancellationToken);
 
                     //TODO: Remove this once repositories for planned absence and vacations are done too
-                    service.ClearConsultantCache(orgUrlKey);
+                    cache.ClearConsultantCache(orgUrlKey);
                     break;
                 case BookingType.PlannedAbsence:
                     var updatedAbsence = CreateAbsence(new PlannedAbsenceKey(staffingWriteModel.EngagementId,
@@ -136,7 +137,7 @@ public class StaffingController(
                     await plannedAbsenceRepository.UpsertPlannedAbsence(updatedAbsence, cancellationToken);
 
                     //TODO: Remove this once repositories for planned absence and vacations are done too
-                    service.ClearConsultantCache(orgUrlKey);
+                    cache.ClearConsultantCache(orgUrlKey);
                     break;
                 case BookingType.Vacation:
                     break;
@@ -186,7 +187,7 @@ public class StaffingController(
                     await staffingRepository.UpsertMultipleStaffings(updatedStaffings, cancellationToken);
 
                     //TODO: Remove this once repositories for planned absence and vacations are done too
-                    service.ClearConsultantCache(orgUrlKey);
+                    cache.ClearConsultantCache(orgUrlKey);
                     break;
                 case BookingType.PlannedAbsence:
                     var updatedAbsences = GenerateUpdatedAbsences(severalStaffingWriteModel.ConsultantId,
@@ -195,7 +196,7 @@ public class StaffingController(
                     await plannedAbsenceRepository.UpsertMultiplePlannedAbsences(updatedAbsences, cancellationToken);
 
                     //TODO: Remove this once repositories for planned absence and vacations are done too
-                    service.ClearConsultantCache(orgUrlKey);
+                    cache.ClearConsultantCache(orgUrlKey);
                     break;
                 case BookingType.Vacation:
                     break;

--- a/backend/Core/Extensions/MemoryCacheExtensions.cs
+++ b/backend/Core/Extensions/MemoryCacheExtensions.cs
@@ -60,9 +60,18 @@ public static class MemoryCacheExtensions
 		return cache.TryGetValue(StaffingCacheKey(consultantId), out staffings);
 	}
 
+	/// <summary>
+	/// The Consultant cache contains basic information about each consultant employed in the given organization. Anything related to staffing (including projects/engagements) and planned absence is cached separately.
+	/// </summary>
 	private static string ConsultantCacheKey(string orgUrlKey) => $"consultantCacheKey/{orgUrlKey}";
 
+	/// <summary>
+	/// The Planned absence cache contains planned absence information for the given consultant
+	/// </summary>
 	private static string PlannedAbsenceCacheKey(int consultantId) => $"PlannedAbsenceCacheRepository/{consultantId}";
 
+	/// <summary>
+	/// The Staffing cache contains staffing and staffing-related information (such as projects/engagements) for the given consultant
+	/// </summary>
 	private static string StaffingCacheKey(int consultantId) => $"StaffingCacheRepository/{consultantId}";
 }

--- a/backend/Core/Extensions/MemoryCacheExtensions.cs
+++ b/backend/Core/Extensions/MemoryCacheExtensions.cs
@@ -1,0 +1,68 @@
+using Core.Consultants;
+using Core.PlannedAbsences;
+using Core.Staffings;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Core.Extensions;
+
+public static class MemoryCacheExtensions
+{
+	public static void ClearConsultantCache(this IMemoryCache cache, string orgUrlKey)
+	{
+		cache.Remove(ConsultantCacheKey(orgUrlKey));
+	}
+
+	public static void SetConsultantCache(this IMemoryCache cache, string orgUrlKey, List<Consultant> consultants)
+	{
+		cache.Set(ConsultantCacheKey(orgUrlKey), consultants);
+	}
+
+	public static bool TryGetFromConsultantCache(this IMemoryCache cache, string orgUrlKey, out List<Consultant>? consultants)
+	{
+		return cache.TryGetValue(ConsultantCacheKey(orgUrlKey), out consultants);
+	}
+
+	public static void ClearPlannedAbsenceFor(this IMemoryCache cache, int consultantId)
+	{
+		cache.Remove(PlannedAbsenceCacheKey(consultantId));
+	}
+
+	public static void SetPlannedAbsenceFor(this IMemoryCache cache, int consultantId, List<PlannedAbsence>? plannedAbsences)
+	{
+		cache.Set(PlannedAbsenceCacheKey(consultantId), plannedAbsences);
+	}
+
+	public static bool TryGetPlannedAbsenceFor(this IMemoryCache cache, int consultantId, out List<PlannedAbsence>? plannedAbsences)
+	{
+		return cache.TryGetValue(PlannedAbsenceCacheKey(consultantId), out plannedAbsences);
+	}
+
+	public static void ClearStaffingFor(this IMemoryCache cache, int consultantId)
+	{
+		cache.Remove(StaffingCacheKey(consultantId));
+	}
+
+	public static void ClearStaffingFor(this IMemoryCache cache, List<int> consultantIds)
+	{
+		foreach (var consultantId in consultantIds)
+		{
+			cache.ClearStaffingFor(consultantId);
+		}
+	}
+
+	public static void SetStaffingFor(this IMemoryCache cache, int consultantId, List<Staffing>? staffings)
+	{
+		cache.Set(StaffingCacheKey(consultantId), staffings);
+	}
+
+	public static bool TryGetStaffingFor(this IMemoryCache cache, int consultantId, out List<Staffing>? staffings)
+	{
+		return cache.TryGetValue(StaffingCacheKey(consultantId), out staffings);
+	}
+
+	private static string ConsultantCacheKey(string orgUrlKey) => $"consultantCacheKey/{orgUrlKey}";
+
+	private static string PlannedAbsenceCacheKey(int consultantId) => $"PlannedAbsenceCacheRepository/{consultantId}";
+
+	private static string StaffingCacheKey(int consultantId) => $"StaffingCacheRepository/{consultantId}";
+}

--- a/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
+++ b/backend/Infrastructure/Repositories/Staffings/StaffingCacheRepository.cs
@@ -1,3 +1,4 @@
+using Core.Extensions;
 using Core.Staffings;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -25,7 +26,7 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
         foreach (var (cId, staffings) in queriedStaffingLists)
         {
             result.Add(cId, staffings);
-            cache.Set(StaffingCacheKey(cId), staffings);
+            cache.SetStaffingFor(cId, staffings);
         }
 
         return result;
@@ -37,7 +38,7 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
         if (staffingList is not null) return staffingList;
 
         staffingList = await sourceRepository.GetStaffingForConsultant(consultantId, cancellationToken);
-        cache.Set(StaffingCacheKey(consultantId), staffingList);
+        cache.SetStaffingFor(consultantId, staffingList);
         return staffingList;
     }
 
@@ -45,7 +46,7 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
     {
         Console.WriteLine($"CACHE UpsertStaffing for consultant #{staffing.ConsultantId}");
         await sourceRepository.UpsertStaffing(staffing, cancellationToken);
-        ClearStaffingCache(staffing.ConsultantId);
+        cache.ClearStaffingFor(staffing.ConsultantId);
     }
 
     public async Task UpsertMultipleStaffings(List<Staffing> staffings, CancellationToken cancellationToken)
@@ -53,26 +54,16 @@ public class StaffingCacheRepository(IStaffingRepository sourceRepository, IMemo
         Console.WriteLine($"CACHE UpsertMultipleStaffings (count: {staffings.Count})");
         await sourceRepository.UpsertMultipleStaffings(staffings, cancellationToken);
 
-        var consultantIds = staffings.Select(staffing => staffing.ConsultantId).Distinct();
-        foreach (var consultantId in consultantIds) ClearStaffingCache(consultantId);
+        var consultantIds = staffings.Select(staffing => staffing.ConsultantId).Distinct().ToList();
+        cache.ClearStaffingFor(consultantIds);
     }
 
     private List<Staffing>? GetStaffingsFromCache(int consultantId)
     {
-        if (cache.TryGetValue<List<Staffing>>(StaffingCacheKey(consultantId), out var staffingList))
+        if (cache.TryGetStaffingFor(consultantId, out var staffingList))
             if (staffingList is not null)
                 return staffingList;
 
         return null;
-    }
-
-    public void ClearStaffingCache(int consultantId)
-    {
-        cache.Remove(StaffingCacheKey(consultantId));
-    }
-
-    private static string StaffingCacheKey(int consultantId)
-    {
-        return $"StaffingCacheRepository/{consultantId}";
     }
 }


### PR DESCRIPTION
The cache is updated both in the `Api` project and `Infrastructure` project. Some cache keys are therefore defined more than once throughout the source code, and some logic is unnecessarily duplicated.

In this PR, all cache-handling logic has been collected in a central class: `MemoryCacheExtensions` in the `Core` project. Short explanations for each cache key have also been added there.