### PR TITLE
Bugfix: Some frontend forecast data was still associated with the datatype Month rather than DateOnly

### DIFF
--- a/backend/Api/Forecasts/ConsultantWithForecast.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecast.cs
@@ -16,14 +16,19 @@ public record ConsultantWithForecast(
 	List<ForecastForMonth> Forecasts,
 	bool ConsultantIsAvailable);
 
-public record BookedHoursInMonth(Month Month, BookingReadModel BookingModel);
+public record BookedHoursInMonth(DateOnly Month, BookingReadModel BookingModel)
+{
+	public BookedHoursInMonth(Month month, BookingReadModel bookingModel) : this(month.FirstDay, bookingModel)
+	{
+	}
+}
 
 public record DetailedBookingForMonth(BookingDetails BookingDetails, List<MonthlyHours> Hours)
 {
 	public double TotalHoursForMonth(Month month)
 	{
 		return Hours
-			.Where(hoursPerMonth => hoursPerMonth.Month.Equals(month))
+			.Where(hoursPerMonth => hoursPerMonth.Month.EqualsMonth(month))
 			.Sum(hoursInMonth => hoursInMonth.Hours);
 	}
 
@@ -46,8 +51,12 @@ public record DetailedBookingForMonth(BookingDetails BookingDetails, List<Monthl
 	}
 }
 
-public record struct MonthlyHours(Month Month, double Hours)
+public record struct MonthlyHours(DateOnly Month, double Hours)
 {
+	public MonthlyHours(Month month, double hours) : this(month.FirstDay, hours)
+	{
+	}
+
 	public static MonthlyHours For(Month month, List<Staffing> staffings, Consultant consultant)
 	{
 		var staffedHoursInMonth = month.GetWeeks()
@@ -88,7 +97,7 @@ public record ForecastForMonth(
 			.SingleOrDefault(f => f.Month.Equals(month))?
 			.AdjustedValue ?? 0;
 
-		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.Equals(month))?.BookingModel;
+		var booking = bookingSummary.SingleOrDefault(bs => bs.Month.EqualsMonth(month))?.BookingModel;
 
 		if (booking == null)
 		{

--- a/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
+++ b/backend/Api/Forecasts/ConsultantWithForecastFactory.cs
@@ -65,7 +65,7 @@ public static class ConsultantWithForecastFactory
 			var vacationHoursPerMonth = months
 				.Select(month => new MonthlyHours(
 					month,
-					Hours: organization.HoursPerWorkday *
+					hours: organization.HoursPerWorkday *
 						   vacations.Count(v => v.Date.EqualsMonth(month))))
 				.ToList();
 


### PR DESCRIPTION
...which led to incorrect styling, popup behavior, and value sums on the forecast page