### PR TITLE
Enabling editing of 'estimated hourly price' for a consultant

### DIFF
--- a/backend/Api/Common/StorageService.cs
+++ b/backend/Api/Common/StorageService.cs
@@ -189,6 +189,7 @@ public class StorageService(IMemoryCache cache, ILogger<StorageService> logger, 
         if (department is not null) consultant.Department = department;
         consultant.GraduationYear = body.GraduationYear;
         consultant.Degree = body.Degree;
+        consultant.EstimatedHourPrice = body.EstimatedHourPrice;
 
         if (body.Discipline?.Id != consultant.DisciplineId)
         {

--- a/backend/Api/Consultants/ConsultantModels.cs
+++ b/backend/Api/Consultants/ConsultantModels.cs
@@ -17,7 +17,8 @@ public record SingleConsultantReadModel(
     int? GraduationYear,
     int YearsOfExperience,
     Degree Degree,
-    DisciplineReadModel? Discipline)
+    DisciplineReadModel? Discipline,
+    int EstimatedHourPrice)
 {
     public SingleConsultantReadModel(Consultant consultant)
         : this(
@@ -31,7 +32,8 @@ public record SingleConsultantReadModel(
             consultant.GraduationYear,
             consultant.YearsOfExperience,
             consultant.Degree ?? Degree.Master,
-            DisciplineReadModel.CreateIfExists(consultant.Discipline)
+            DisciplineReadModel.CreateIfExists(consultant.Discipline),
+            consultant.EstimatedHourPrice
         )
     {
     }
@@ -62,4 +64,5 @@ public record ConsultantWriteModel(
     UpdateDepartmentReadModel Department,
     int GraduationYear,
     Degree Degree,
-    DisciplineReadModel? Discipline);
+    DisciplineReadModel? Discipline,
+    int EstimatedHourPrice);

--- a/frontend/mockdata/mockData.ts
+++ b/frontend/mockdata/mockData.ts
@@ -418,5 +418,6 @@ export const MockConsultants: ConsultantReadModel[] = [
     isOccupied: true,
     graduationYear: 2010,
     degree: Degree.Bachelor,
+    estimatedHourPrice: 1200,
   },
 ];

--- a/frontend/src/api-types.ts
+++ b/frontend/src/api-types.ts
@@ -58,6 +58,8 @@ export interface ConsultantReadModel {
   yearsOfExperience: number;
   graduationYear: number;
   degree: Degree;
+  /** @format int32 */
+  estimatedHourPrice: number;
   bookings: BookedHoursPerWeek[];
   detailedBooking: DetailedBooking[];
   isOccupied: boolean;
@@ -76,6 +78,8 @@ export interface ConsultantWriteModel {
   degree: Degree;
   /** @format int32 */
   graduationYear: number;
+  /** @format int32 */
+  estimatedHourPrice: number;
   startDate: Date;
   endDate?: Date;
 }
@@ -222,6 +226,8 @@ export interface SingleConsultantReadModel {
   graduationYear: number;
   /** @format int32 */
   yearsOfExperience: number;
+  /** @format int32 */
+  estimatedHourPrice: number;
   degree: Degree;
   imageUrl?: string;
   imageThumbUrl?: string;

--- a/frontend/src/components/consultants/AddNewConsultantModal.tsx
+++ b/frontend/src/components/consultants/AddNewConsultantModal.tsx
@@ -21,6 +21,7 @@ export default function AddNewConsultantModal({
     degree: Degree.None,
     graduationYear: new Date().getFullYear(),
     startDate: new Date(),
+    estimatedHourPrice: 0,
   });
   const { competences, departments } = useContext(FilteredContext);
   const { organisation } = useParams();

--- a/frontend/src/components/consultants/EditableTableNumberCell.tsx
+++ b/frontend/src/components/consultants/EditableTableNumberCell.tsx
@@ -20,6 +20,15 @@ export default function EditableTableNumberCell({
     }
   }, [newValue]);
 
+  function withThousandSeparator(number: number): string {
+    if (number < 1000) return String(number);
+
+    const beforeSeparator = String(Math.floor(newValue / 1000));
+    const afterSeparator = String(Math.floor(newValue % 1000));
+
+    return `${beforeSeparator} ${afterSeparator.padStart(3, "000")}`;
+  }
+
   return (
     <td className="pr-3">
       {isEditing ? (
@@ -31,8 +40,10 @@ export default function EditableTableNumberCell({
           onChange={(e) => setNewValue(Number(e.target.value))}
         />
       ) : (
-        <p className={style ? style : "normal text-text_light_black"}>
-          {newValue}
+        <p
+          className={style ? style : "normal text-text_light_black float-right"}
+        >
+          { withThousandSeparator(newValue) }
         </p>
       )}
     </td>

--- a/frontend/src/components/consultants/EditableTableNumberCell.tsx
+++ b/frontend/src/components/consultants/EditableTableNumberCell.tsx
@@ -1,0 +1,40 @@
+"use client";
+import React, { useEffect, useState } from "react";
+
+export default function EditableTableNumberCell({
+  number,
+  setConsultant,
+  isEditing,
+  style,
+}: {
+  number: number;
+  setConsultant: (number: number) => void;
+  isEditing: boolean;
+  style?: string;
+}) {
+  const [newValue, setNewValue] = useState<number>(number);
+
+  useEffect(() => {
+    if (isEditing) {
+      setConsultant(newValue);
+    }
+  }, [newValue]);
+
+  return (
+    <td className="pr-3">
+      {isEditing ? (
+        <input
+          className="w-full py-2 px-3 border border-primary_50 rounded-md focus:outline-none focus:ring-1 focus:ring-primary text-sm"
+          type="number"
+          min="0"
+          value={newValue}
+          onChange={(e) => setNewValue(Number(e.target.value))}
+        />
+      ) : (
+        <p className={style ? style : "normal text-text_light_black"}>
+          {newValue}
+        </p>
+      )}
+    </td>
+  );
+}

--- a/frontend/src/components/consultants/EditableTableNumberCell.tsx
+++ b/frontend/src/components/consultants/EditableTableNumberCell.tsx
@@ -29,9 +29,7 @@ export default function EditableTableNumberCell({
           onChange={(e) => setNewValue(Number(e.target.value))}
         />
       ) : (
-        <p
-          className="normal text-text_light_black float-right"
-        >
+        <p className="normal text-text_light_black float-right">
           {newValue.toLocaleString("no-nb")}
         </p>
       )}

--- a/frontend/src/components/consultants/EditableTableNumberCell.tsx
+++ b/frontend/src/components/consultants/EditableTableNumberCell.tsx
@@ -20,15 +20,6 @@ export default function EditableTableNumberCell({
     }
   }, [newValue]);
 
-  function withThousandSeparator(number: number): string {
-    if (number < 1000) return String(number);
-
-    const beforeSeparator = String(Math.floor(newValue / 1000));
-    const afterSeparator = String(Math.floor(newValue % 1000));
-
-    return `${beforeSeparator} ${afterSeparator.padStart(3, "000")}`;
-  }
-
   return (
     <td className="pr-3">
       {isEditing ? (
@@ -43,7 +34,7 @@ export default function EditableTableNumberCell({
         <p
           className={style ? style : "normal text-text_light_black float-right"}
         >
-          {withThousandSeparator(newValue)}
+          {newValue.toLocaleString("no-nb")}
         </p>
       )}
     </td>

--- a/frontend/src/components/consultants/EditableTableNumberCell.tsx
+++ b/frontend/src/components/consultants/EditableTableNumberCell.tsx
@@ -43,7 +43,7 @@ export default function EditableTableNumberCell({
         <p
           className={style ? style : "normal text-text_light_black float-right"}
         >
-          { withThousandSeparator(newValue) }
+          {withThousandSeparator(newValue)}
         </p>
       )}
     </td>

--- a/frontend/src/components/consultants/EditableTableNumberCell.tsx
+++ b/frontend/src/components/consultants/EditableTableNumberCell.tsx
@@ -5,12 +5,10 @@ export default function EditableTableNumberCell({
   number,
   setConsultant,
   isEditing,
-  style,
 }: {
   number: number;
   setConsultant: (number: number) => void;
   isEditing: boolean;
-  style?: string;
 }) {
   const [newValue, setNewValue] = useState<number>(number);
 
@@ -32,7 +30,7 @@ export default function EditableTableNumberCell({
         />
       ) : (
         <p
-          className={style ? style : "normal text-text_light_black float-right"}
+          className="normal text-text_light_black float-right"
         >
           {newValue.toLocaleString("no-nb")}
         </p>

--- a/frontend/src/components/consultants/FilteredConsultantsComp.tsx
+++ b/frontend/src/components/consultants/FilteredConsultantsComp.tsx
@@ -157,7 +157,7 @@ export default function FilteredConsultantsComp({
             </div>
           </th>
 
-          <th className="py-1 pt-3 w-32">
+          <th className="py-1 pt-3 w-20">
             <div className="flex flex-col gap-1">
               <p className="normal text-left" title="Estimert timepris">
                 Timepris

--- a/frontend/src/components/consultants/FilteredConsultantsComp.tsx
+++ b/frontend/src/components/consultants/FilteredConsultantsComp.tsx
@@ -159,7 +159,9 @@ export default function FilteredConsultantsComp({
 
           <th className="py-1 pt-3 w-32">
             <div className="flex flex-col gap-1">
-              <p className="normal text-left" title="Estimert timepris">Timepris</p>
+              <p className="normal text-left" title="Estimert timepris">
+                Timepris
+              </p>
             </div>
           </th>
 
@@ -339,7 +341,10 @@ export default function FilteredConsultantsComp({
                 setConsultant={(hourPrice: number) =>
                   setSelectedEditConsultant((selectedConsultant) => {
                     if (!selectedConsultant) return null;
-                    return { ...selectedConsultant, estimatedHourPrice: hourPrice };
+                    return {
+                      ...selectedConsultant,
+                      estimatedHourPrice: hourPrice,
+                    };
                   })
                 }
                 number={consultant.estimatedHourPrice}

--- a/frontend/src/components/consultants/FilteredConsultantsComp.tsx
+++ b/frontend/src/components/consultants/FilteredConsultantsComp.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { Edit3, Check } from "react-feather";
 import EditableTableTextCell from "./EditableTableTextCell";
+import EditableTableNumberCell from "./EditableTableNumberCell";
 import EditableTableDateCell from "./EditableTableDateCell";
 import { FilteredContext } from "@/hooks/ConsultantFilterProvider";
 import EditableTableSelectDepartmentCell from "./EditableTableSelectDepartmentCell";
@@ -155,6 +156,13 @@ export default function FilteredConsultantsComp({
               <p className="normal text-left">Eksamensår</p>
             </div>
           </th>
+
+          <th className="py-1 pt-3 w-32">
+            <div className="flex flex-col gap-1">
+              <p className="normal text-left" title="Estimert timepris">Timepris</p>
+            </div>
+          </th>
+
           <th className="py-1 pt-3 w-14">
             <div className="flex flex-col gap-1"></div>
           </th>
@@ -324,6 +332,17 @@ export default function FilteredConsultantsComp({
                   })
                 }
                 gradYear={consultant.graduationYear}
+                isEditing={selectedEditConsultant?.id === consultant.id}
+              />
+
+              <EditableTableNumberCell
+                setConsultant={(hourPrice: number) =>
+                  setSelectedEditConsultant((selectedConsultant) => {
+                    if (!selectedConsultant) return null;
+                    return { ...selectedConsultant, estimatedHourPrice: hourPrice };
+                  })
+                }
+                number={consultant.estimatedHourPrice}
                 isEditing={selectedEditConsultant?.id === consultant.id}
               />
 

--- a/frontend/src/components/consultants/FilteredConsultantsComp.tsx
+++ b/frontend/src/components/consultants/FilteredConsultantsComp.tsx
@@ -9,7 +9,7 @@ import {
 import { useSimpleConsultantsFilter } from "@/hooks/staffing/useConsultantsFilter";
 import Image from "next/image";
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { Edit3, Check } from "react-feather";
+import { Edit3, Check, Info } from "react-feather";
 import EditableTableTextCell from "./EditableTableTextCell";
 import EditableTableNumberCell from "./EditableTableNumberCell";
 import EditableTableDateCell from "./EditableTableDateCell";
@@ -161,6 +161,9 @@ export default function FilteredConsultantsComp({
             <div className="flex flex-col gap-1">
               <p className="normal text-left" title="Estimert timepris">
                 Timepris
+                <span className="pl-1">
+                  <Info className="inline" size="15" />
+                </span>
               </p>
             </div>
           </th>


### PR DESCRIPTION
Enabling editing of the _estimated hourly price_ for a consultant on the consultant page by:
- adding the `EstimatedHourPrice` property to the models used in frontend
- creating an editable table number cell component
- adding a column to the filtered consultants component for the estimated hour price, using the new editable component
