### PR TITLE
Displaying income and realized hourly rate summary rows on the forecast page

### DIFF
--- a/frontend/src/components/Forecast/ForecastSumRow.tsx
+++ b/frontend/src/components/Forecast/ForecastSumRow.tsx
@@ -1,0 +1,35 @@
+export function ForecastSumRow({
+  title,
+  values,
+  minFractionDigits = 1,
+  maxFractionDigits = 1,
+  displayPercentage,
+}: {
+  title: string;
+  values: number[];
+  minFractionDigits?: number;
+  maxFractionDigits?: number;
+  displayPercentage?: boolean;
+}) {
+  function displayValue(value: number) {
+    if (displayPercentage) return `${Math.round(value * 100)} %`;
+
+    return value.toLocaleString("nb-No", {
+      minimumFractionDigits: minFractionDigits,
+      maximumFractionDigits: maxFractionDigits,
+    });
+  }
+
+  return (
+    <tr>
+      <td colSpan={1}>
+        <p className="small-medium text-black">{title}</p>
+      </td>
+      {values?.map((value, index) => (
+        <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
+          <p className="small-medium text-right">{displayValue(value)}</p>
+        </td>
+      ))}
+    </tr>
+  );
+}

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -57,7 +57,10 @@ export function ForecastSums({
     const realizedHourlyRates = Array<number>(count);
 
     for (let i = 0; i < count; i++) {
-      realizedHourlyRates[i] = Math.floor(hours[i] / income[i]);
+      const realizedHourlyRate =
+        hours[i] === 0 ? 0 : Math.floor(income[i] / hours[i]);
+
+      realizedHourlyRates[i] = realizedHourlyRate;
     }
 
     return realizedHourlyRates;
@@ -69,28 +72,49 @@ export function ForecastSums({
         <th align="left">Ordre</th>
       </tr>
       <SumRow title="Sum timer" values={totalBillableHours} />
-      <SumRow title="Total inntekt" values={totalBillableIncome} />
+      <SumRow
+        title="Total inntekt"
+        values={totalBillableIncome}
+        minFractionDigits={0}
+        maxFractionDigits={0}
+      />
       <SumRow
         title="Oppnådd timepris (OT)"
         values={totalBillableRealizedHourlyRate}
+        minFractionDigits={0}
+        maxFractionDigits={0}
       />
       <tr>
         <th align="left">Ordre, opsjon og tilbud</th>
       </tr>
       <SumRow title="Sum timer" values={totalBillableAndOfferedHours} />
-      <SumRow title="Total inntekt" values={totalBillableAndOfferedIncome} />
+      <SumRow
+        title="Total inntekt"
+        values={totalBillableAndOfferedIncome}
+        minFractionDigits={0}
+        maxFractionDigits={0}
+      />
       <SumRow
         title="Oppnådd timepris (OT)"
         values={totalBillableAndOfferedRealizedHourlyRate}
+        minFractionDigits={0}
+        maxFractionDigits={0}
       />
       <tr>
         <th align="left">Prognose</th>
       </tr>
       <SumRow title="Sum timer" values={monthlyForecastHours} />
-      <SumRow title="Total inntekt" values={forecastIncome} />
+      <SumRow
+        title="Total inntekt"
+        values={forecastIncome}
+        minFractionDigits={0}
+        maxFractionDigits={0}
+      />
       <SumRow
         title="Oppnådd timepris (OT)"
         values={forecastRealizedHourlyRate}
+        minFractionDigits={0}
+        maxFractionDigits={0}
       />
       <SumRow
         title="Faktureringsgrad"

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -2,34 +2,98 @@ import { SumRow } from "../SumRow";
 
 interface ForecastSumsProps {
   monthlyTotalBillable: Map<number, number>;
+  monthlyTotalBillableIncome: Map<number, number>;
   monthlyTotalBillableAndOffered: Map<number, number>;
+  monthlyTotalBillableAndOfferedIncome: Map<number, number>;
   monthlyInvoiceRates: Map<number, number>;
   monthlyForecastTotalHours: Map<number, number>;
+  monthlyForecastIncome: Map<number, number>;
 }
 
 export function ForecastSums({
   monthlyTotalBillable,
+  monthlyTotalBillableIncome,
   monthlyTotalBillableAndOffered,
+  monthlyTotalBillableAndOfferedIncome,
   monthlyInvoiceRates,
   monthlyForecastTotalHours,
+  monthlyForecastIncome,
 }: ForecastSumsProps) {
+  // Billable
   const totalBillableHours = Array.from(monthlyTotalBillable.values());
+  const totalBillableIncome = Array.from(monthlyTotalBillableIncome.values());
+  const totalBillableRealizedHourlyRate = realizedHourlyRateArray(
+    totalBillableHours,
+    totalBillableIncome,
+  );
+
+  // Billable and offered
   const totalBillableAndOfferedHours = Array.from(
     monthlyTotalBillableAndOffered.values(),
   );
+  const totalBillableAndOfferedIncome = Array.from(
+    monthlyTotalBillableAndOfferedIncome.values(),
+  );
+  const totalBillableAndOfferedRealizedHourlyRate = realizedHourlyRateArray(
+    totalBillableAndOfferedHours,
+    totalBillableAndOfferedIncome,
+  );
+
+  // Forecast
   const monthlyForecastHours = Array.from(monthlyForecastTotalHours.values());
+  const forecastIncome = Array.from(monthlyForecastIncome.values());
+  const forecastRealizedHourlyRate = realizedHourlyRateArray(
+    monthlyForecastHours,
+    forecastIncome,
+  );
   const monthlyInvoiceRatesArray = Array.from(monthlyInvoiceRates.values());
+
+  function realizedHourlyRateArray(
+    hours: number[],
+    income: number[],
+  ): number[] {
+    const count = [hours.length, income.length].sort()[0];
+
+    const realizedHourlyRates = Array<number>(count);
+
+    for (let i = 0; i < count; i++) {
+      realizedHourlyRates[i] = Math.floor(hours[i] / income[i]);
+    }
+
+    return realizedHourlyRates;
+  }
 
   return (
     <thead className="border-t-[3px] border-t-primary/20">
-      <SumRow title="Sum ordre" values={totalBillableHours} />
+      <tr>
+        <th align="left">Ordre</th>
+      </tr>
+      <SumRow title="Sum timer" values={totalBillableHours} />
+      <SumRow title="Total inntekt" values={totalBillableIncome} />
       <SumRow
-        title="Sum ordre, opsjon og tilbud"
-        values={totalBillableAndOfferedHours}
+        title="Oppnådd timepris (OT)"
+        values={totalBillableRealizedHourlyRate}
       />
-      <SumRow title="Prognosetall i timer" values={monthlyForecastHours} />
+      <tr>
+        <th align="left">Ordre, opsjon og tilbud</th>
+      </tr>
+      <SumRow title="Sum timer" values={totalBillableAndOfferedHours} />
+      <SumRow title="Total inntekt" values={totalBillableAndOfferedIncome} />
       <SumRow
-        title="Prognostisert faktureringsgrad"
+        title="Oppnådd timepris (OT)"
+        values={totalBillableAndOfferedRealizedHourlyRate}
+      />
+      <tr>
+        <th align="left">Prognose</th>
+      </tr>
+      <SumRow title="Sum timer" values={monthlyForecastHours} />
+      <SumRow title="Total inntekt" values={forecastIncome} />
+      <SumRow
+        title="Oppnådd timepris (OT)"
+        values={forecastRealizedHourlyRate}
+      />
+      <SumRow
+        title="Faktureringsgrad"
         values={monthlyInvoiceRatesArray}
         displayPercentage={true}
       />

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -67,7 +67,8 @@ export function ForecastSums({
   }
 
   return (
-    <thead className="border-t-[3px] border-t-primary/20">
+    <>
+    <tbody className="border-t-[3px] border-t-primary/20">
       <tr>
         <th align="left">Ordre</th>
       </tr>
@@ -84,8 +85,10 @@ export function ForecastSums({
         minFractionDigits={0}
         maxFractionDigits={0}
       />
+    </tbody>
+    <tbody className="bg-background_light_purple">
       <tr>
-        <th align="left">Ordre, opsjon og tilbud</th>
+        <th align="left" colSpan={20}>Ordre, opsjon og tilbud</th>
       </tr>
       <SumRow title="Sum timer" values={totalBillableAndOfferedHours} />
       <SumRow
@@ -100,6 +103,8 @@ export function ForecastSums({
         minFractionDigits={0}
         maxFractionDigits={0}
       />
+    </tbody>
+    <tbody>
       <tr>
         <th align="left">Prognose</th>
       </tr>
@@ -121,6 +126,7 @@ export function ForecastSums({
         values={monthlyInvoiceRatesArray}
         displayPercentage={true}
       />
-    </thead>
+    </tbody>
+    </>
   );
 }

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ForecastSumRow } from "./ForecastSumRow";
+import { SumRow } from "../SumRow";
 
 interface ForecastSumsProps {
   monthlyTotalBillable?: Map<number, number>;
@@ -38,20 +38,17 @@ export function ForecastSums({
   return (
     <thead className="border-t-[3px] border-t-primary/20">
       {monthlyTotalBillable && (
-        <ForecastSumRow title="Sum ordre" values={totalBillableHours!} />
+        <SumRow title="Sum ordre" values={totalBillableHours!} />
       )}
-      <ForecastSumRow
+      <SumRow
         title="Sum ordre, opsjon og tilbud"
         values={totalBillableAndOfferedHours}
       />
       {monthlyForecastHours && (
-        <ForecastSumRow
-          title="Prognosetall i timer"
-          values={monthlyForecastHours}
-        />
+        <SumRow title="Prognosetall i timer" values={monthlyForecastHours} />
       )}
       {monthlyInvoiceRatesArray && (
-        <ForecastSumRow
+        <SumRow
           title="Prognostisert faktureringsgrad"
           values={monthlyInvoiceRatesArray}
           displayPercentage={true}

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ForecastSumRow } from "./ForecastSumRow";
 
 interface ForecastSumsProps {
   monthlyTotalBillable?: Map<number, number>;
@@ -37,71 +38,24 @@ export function ForecastSums({
   return (
     <thead className="border-t-[3px] border-t-primary/20">
       {monthlyTotalBillable && (
-        <tr>
-          <td colSpan={1}>
-            <p className="small-medium text-black">Sum ordre</p>
-          </td>
-          {totalBillableHours?.map((totalBillableHour, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {totalBillableHour.toLocaleString("nb-No", {
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                })}
-              </p>
-            </td>
-          ))}
-        </tr>
+        <ForecastSumRow title="Sum ordre" values={totalBillableHours!} />
       )}
-      <tr>
-        <td colSpan={1}>
-          <p className="small-medium text-black">Sum ordre, opsjon og tilbud</p>
-        </td>
-        {totalBillableAndOfferedHours.map(
-          (totalBillableAndOfferedHour, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {totalBillableAndOfferedHour.toLocaleString("nb-No", {
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                })}
-              </p>
-            </td>
-          ),
-        )}
-      </tr>
+      <ForecastSumRow
+        title="Sum ordre, opsjon og tilbud"
+        values={totalBillableAndOfferedHours}
+      />
       {monthlyForecastHours && (
-        <tr>
-          <td colSpan={1}>
-            <p className="small-medium text-black">Prognosetall i timer</p>
-          </td>
-          {monthlyForecastHours.map((indexRates, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {indexRates.toLocaleString("nb-No", {
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                })}
-              </p>
-            </td>
-          ))}
-        </tr>
+        <ForecastSumRow
+          title="Prognosetall i timer"
+          values={monthlyForecastHours}
+        />
       )}
       {monthlyInvoiceRatesArray && (
-        <tr>
-          <td colSpan={1}>
-            <p className="small-medium text-black">
-              Prognostisert faktureringsgrad
-            </p>
-          </td>
-          {monthlyInvoiceRatesArray.map((indexRates, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {Math.round(indexRates * 100)}%
-              </p>
-            </td>
-          ))}
-        </tr>
+        <ForecastSumRow
+          title="Prognostisert faktureringsgrad"
+          values={monthlyInvoiceRatesArray}
+          displayPercentage={true}
+        />
       )}
     </thead>
   );

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -68,65 +68,67 @@ export function ForecastSums({
 
   return (
     <>
-    <tbody className="border-t-[3px] border-t-primary/20">
-      <tr>
-        <th align="left">Ordre</th>
-      </tr>
-      <SumRow title="Sum timer" values={totalBillableHours} />
-      <SumRow
-        title="Total inntekt"
-        values={totalBillableIncome}
-        minFractionDigits={0}
-        maxFractionDigits={0}
-      />
-      <SumRow
-        title="Oppnådd timepris (OT)"
-        values={totalBillableRealizedHourlyRate}
-        minFractionDigits={0}
-        maxFractionDigits={0}
-      />
-    </tbody>
-    <tbody className="bg-background_light_purple">
-      <tr>
-        <th align="left" colSpan={20}>Ordre, opsjon og tilbud</th>
-      </tr>
-      <SumRow title="Sum timer" values={totalBillableAndOfferedHours} />
-      <SumRow
-        title="Total inntekt"
-        values={totalBillableAndOfferedIncome}
-        minFractionDigits={0}
-        maxFractionDigits={0}
-      />
-      <SumRow
-        title="Oppnådd timepris (OT)"
-        values={totalBillableAndOfferedRealizedHourlyRate}
-        minFractionDigits={0}
-        maxFractionDigits={0}
-      />
-    </tbody>
-    <tbody>
-      <tr>
-        <th align="left">Prognose</th>
-      </tr>
-      <SumRow title="Sum timer" values={monthlyForecastHours} />
-      <SumRow
-        title="Total inntekt"
-        values={forecastIncome}
-        minFractionDigits={0}
-        maxFractionDigits={0}
-      />
-      <SumRow
-        title="Oppnådd timepris (OT)"
-        values={forecastRealizedHourlyRate}
-        minFractionDigits={0}
-        maxFractionDigits={0}
-      />
-      <SumRow
-        title="Faktureringsgrad"
-        values={monthlyInvoiceRatesArray}
-        displayPercentage={true}
-      />
-    </tbody>
+      <tbody className="border-t-[3px] border-t-primary/20">
+        <tr>
+          <th align="left">Ordre</th>
+        </tr>
+        <SumRow title="Sum timer" values={totalBillableHours} />
+        <SumRow
+          title="Total inntekt"
+          values={totalBillableIncome}
+          minFractionDigits={0}
+          maxFractionDigits={0}
+        />
+        <SumRow
+          title="Oppnådd timepris (OT)"
+          values={totalBillableRealizedHourlyRate}
+          minFractionDigits={0}
+          maxFractionDigits={0}
+        />
+      </tbody>
+      <tbody className="bg-background_light_purple">
+        <tr>
+          <th align="left" colSpan={20}>
+            Ordre, opsjon og tilbud
+          </th>
+        </tr>
+        <SumRow title="Sum timer" values={totalBillableAndOfferedHours} />
+        <SumRow
+          title="Total inntekt"
+          values={totalBillableAndOfferedIncome}
+          minFractionDigits={0}
+          maxFractionDigits={0}
+        />
+        <SumRow
+          title="Oppnådd timepris (OT)"
+          values={totalBillableAndOfferedRealizedHourlyRate}
+          minFractionDigits={0}
+          maxFractionDigits={0}
+        />
+      </tbody>
+      <tbody>
+        <tr>
+          <th align="left">Prognose</th>
+        </tr>
+        <SumRow title="Sum timer" values={monthlyForecastHours} />
+        <SumRow
+          title="Total inntekt"
+          values={forecastIncome}
+          minFractionDigits={0}
+          maxFractionDigits={0}
+        />
+        <SumRow
+          title="Oppnådd timepris (OT)"
+          values={forecastRealizedHourlyRate}
+          minFractionDigits={0}
+          maxFractionDigits={0}
+        />
+        <SumRow
+          title="Faktureringsgrad"
+          values={monthlyInvoiceRatesArray}
+          displayPercentage={true}
+        />
+      </tbody>
     </>
   );
 }

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -72,16 +72,18 @@ export function ForecastSums({
         <tr>
           <th align="left">Ordre</th>
         </tr>
-        <SumRow title="Sum timer" values={totalBillableHours} />
+        <SumRow title="Sum timer" values={totalBillableHours} unit="t" />
         <SumRow
           title="Total inntekt"
           values={totalBillableIncome}
+          unit="kr"
           minFractionDigits={0}
           maxFractionDigits={0}
         />
         <SumRow
           title="Oppnådd timepris (OT)"
           values={totalBillableRealizedHourlyRate}
+          unit="kr"
           minFractionDigits={0}
           maxFractionDigits={0}
         />
@@ -92,16 +94,22 @@ export function ForecastSums({
             Ordre, opsjon og tilbud
           </th>
         </tr>
-        <SumRow title="Sum timer" values={totalBillableAndOfferedHours} />
+        <SumRow
+          title="Sum timer"
+          values={totalBillableAndOfferedHours}
+          unit="t"
+        />
         <SumRow
           title="Total inntekt"
           values={totalBillableAndOfferedIncome}
+          unit="kr"
           minFractionDigits={0}
           maxFractionDigits={0}
         />
         <SumRow
           title="Oppnådd timepris (OT)"
           values={totalBillableAndOfferedRealizedHourlyRate}
+          unit="kr"
           minFractionDigits={0}
           maxFractionDigits={0}
         />
@@ -110,16 +118,18 @@ export function ForecastSums({
         <tr>
           <th align="left">Prognose</th>
         </tr>
-        <SumRow title="Sum timer" values={monthlyForecastHours} />
+        <SumRow title="Sum timer" values={monthlyForecastHours} unit="t" />
         <SumRow
           title="Total inntekt"
           values={forecastIncome}
+          unit="kr"
           minFractionDigits={0}
           maxFractionDigits={0}
         />
         <SumRow
           title="Oppnådd timepris (OT)"
           values={forecastRealizedHourlyRate}
+          unit="kr"
           minFractionDigits={0}
           maxFractionDigits={0}
         />

--- a/frontend/src/components/Forecast/ForecastSums.tsx
+++ b/frontend/src/components/Forecast/ForecastSums.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
 import { SumRow } from "../SumRow";
 
 interface ForecastSumsProps {
-  monthlyTotalBillable?: Map<number, number>;
+  monthlyTotalBillable: Map<number, number>;
   monthlyTotalBillableAndOffered: Map<number, number>;
-  monthlyInvoiceRates?: Map<number, number>;
+  monthlyInvoiceRates: Map<number, number>;
   monthlyForecastTotalHours: Map<number, number>;
 }
 
@@ -14,46 +13,26 @@ export function ForecastSums({
   monthlyInvoiceRates,
   monthlyForecastTotalHours,
 }: ForecastSumsProps) {
-  const [totalBillableHours, setTotalBillableHours] = useState<number[]>();
+  const totalBillableHours = Array.from(monthlyTotalBillable.values());
   const totalBillableAndOfferedHours = Array.from(
     monthlyTotalBillableAndOffered.values(),
   );
-  const [monthlyInvoiceRatesArray, setMonthlyInvoiceRatesArray] =
-    useState<number[]>();
-  const [monthlyForecastHours, setMonthlyForecastHours] = useState<number[]>();
-
-  useEffect(() => {
-    if (monthlyTotalBillable) {
-      setTotalBillableHours(Array.from(monthlyTotalBillable.values()));
-    }
-    if (monthlyInvoiceRates) {
-      setMonthlyInvoiceRatesArray(Array.from(monthlyInvoiceRates.values()));
-    }
-
-    if (monthlyForecastTotalHours) {
-      setMonthlyForecastHours(Array.from(monthlyForecastTotalHours.values()));
-    }
-  }, [monthlyTotalBillable, monthlyInvoiceRates]);
+  const monthlyForecastHours = Array.from(monthlyForecastTotalHours.values());
+  const monthlyInvoiceRatesArray = Array.from(monthlyInvoiceRates.values());
 
   return (
     <thead className="border-t-[3px] border-t-primary/20">
-      {monthlyTotalBillable && (
-        <SumRow title="Sum ordre" values={totalBillableHours!} />
-      )}
+      <SumRow title="Sum ordre" values={totalBillableHours} />
       <SumRow
         title="Sum ordre, opsjon og tilbud"
         values={totalBillableAndOfferedHours}
       />
-      {monthlyForecastHours && (
-        <SumRow title="Prognosetall i timer" values={monthlyForecastHours} />
-      )}
-      {monthlyInvoiceRatesArray && (
-        <SumRow
-          title="Prognostisert faktureringsgrad"
-          values={monthlyInvoiceRatesArray}
-          displayPercentage={true}
-        />
-      )}
+      <SumRow title="Prognosetall i timer" values={monthlyForecastHours} />
+      <SumRow
+        title="Prognostisert faktureringsgrad"
+        values={monthlyInvoiceRatesArray}
+        displayPercentage={true}
+      />
     </thead>
   );
 }

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -28,10 +28,13 @@ export default function ForecastTable() {
     numWorkHours,
     filteredConsultants,
     monthlyTotalBillable,
+    monthlyTotalBillableIncome,
     monthlyTotalBillableAndOffered,
+    monthlyTotalBillableAndOfferedIncome,
     weeklyInvoiceRates,
     monthlyForecastSums,
     monthlyForecastTotalHours,
+    monthlyForecastIncome,
   } = useForecastFilter();
   const [publicHolidays, setPublicHolidays] = useState<string[]>([]);
   const organisationName = usePathname().split("/")[1];
@@ -159,12 +162,14 @@ export default function ForecastTable() {
       </tbody>
       <ForecastSums
         monthlyTotalBillable={monthlyTotalBillable}
-        monthlyTotalBillableIncome={new Map<number, number>()}
+        monthlyTotalBillableIncome={monthlyTotalBillableIncome}
         monthlyInvoiceRates={weeklyInvoiceRates}
-        monthlyTotalBillableAndOfferedIncome={new Map<number, number>()}
         monthlyTotalBillableAndOffered={monthlyTotalBillableAndOffered}
+        monthlyTotalBillableAndOfferedIncome={
+          monthlyTotalBillableAndOfferedIncome
+        }
         monthlyForecastTotalHours={monthlyForecastTotalHours}
-        monthlyForecastIncome={new Map<number, number>()}
+        monthlyForecastIncome={monthlyForecastIncome}
       />
     </table>
   );

--- a/frontend/src/components/Forecast/ForecastTable.tsx
+++ b/frontend/src/components/Forecast/ForecastTable.tsx
@@ -159,9 +159,12 @@ export default function ForecastTable() {
       </tbody>
       <ForecastSums
         monthlyTotalBillable={monthlyTotalBillable}
+        monthlyTotalBillableIncome={new Map<number, number>()}
         monthlyInvoiceRates={weeklyInvoiceRates}
+        monthlyTotalBillableAndOfferedIncome={new Map<number, number>()}
         monthlyTotalBillableAndOffered={monthlyTotalBillableAndOffered}
         monthlyForecastTotalHours={monthlyForecastTotalHours}
+        monthlyForecastIncome={new Map<number, number>()}
       />
     </table>
   );

--- a/frontend/src/components/StaffingSums.tsx
+++ b/frontend/src/components/StaffingSums.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { SumRow } from "./SumRow";
 
 interface StaffingSumsProps {
   weeklyTotalBillable?: Map<number, number>;
@@ -30,52 +31,20 @@ export default function StaffingSums({
   return (
     <thead>
       {weeklyTotalBillable && (
-        <tr>
-          <td colSpan={2}>
-            <p className="small-medium text-black">Sum ordre</p>
-          </td>
-          {totalBillableHours?.map((totalBillableHour, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {totalBillableHour.toLocaleString("nb-No", {
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                })}
-              </p>
-            </td>
-          ))}
-        </tr>
+        <SumRow title="Sum ordre" values={totalBillableHours!} colSpan={2} />
       )}
-      <tr>
-        <td colSpan={2}>
-          <p className="small-medium text-black">Sum ordre, opsjon og tilbud</p>
-        </td>
-        {totalBillableAndOfferedHours.map(
-          (totalBillableAndOfferedHour, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {totalBillableAndOfferedHour.toLocaleString("nb-No", {
-                  maximumFractionDigits: 1,
-                  minimumFractionDigits: 1,
-                })}
-              </p>
-            </td>
-          ),
-        )}
-      </tr>
+      <SumRow
+        title="Sum ordre, opsjon og tilbud"
+        values={totalBillableAndOfferedHours}
+        colSpan={2}
+      />
       {weeklyInvoiceRatesArray && (
-        <tr>
-          <td colSpan={2}>
-            <p className="small-medium text-black">Faktureringsgrad</p>
-          </td>
-          {weeklyInvoiceRatesArray.map((indexRates, index) => (
-            <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-              <p className="small-medium text-right">
-                {Math.round(indexRates * 100)}%
-              </p>
-            </td>
-          ))}
-        </tr>
+        <SumRow
+          title="Faktureringsgrad"
+          values={weeklyInvoiceRatesArray}
+          colSpan={2}
+          displayPercentage={true}
+        />
       )}
     </thead>
   );

--- a/frontend/src/components/SumRow.tsx
+++ b/frontend/src/components/SumRow.tsx
@@ -1,12 +1,14 @@
 export function SumRow({
   title,
   values,
+  colSpan = 1,
   minFractionDigits = 1,
   maxFractionDigits = 1,
   displayPercentage,
 }: {
   title: string;
   values: number[];
+  colSpan?: number;
   minFractionDigits?: number;
   maxFractionDigits?: number;
   displayPercentage?: boolean;
@@ -22,7 +24,7 @@ export function SumRow({
 
   return (
     <tr>
-      <td colSpan={1}>
+      <td colSpan={colSpan}>
         <p className="small-medium text-black">{title}</p>
       </td>
       {values?.map((value, index) => (

--- a/frontend/src/components/SumRow.tsx
+++ b/frontend/src/components/SumRow.tsx
@@ -1,6 +1,7 @@
 export function SumRow({
   title,
   values,
+  unit,
   colSpan = 1,
   minFractionDigits = 1,
   maxFractionDigits = 1,
@@ -8,6 +9,7 @@ export function SumRow({
 }: {
   title: string;
   values: number[];
+  unit?: string;
   colSpan?: number;
   minFractionDigits?: number;
   maxFractionDigits?: number;
@@ -29,7 +31,9 @@ export function SumRow({
       </td>
       {values?.map((value, index) => (
         <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">
-          <p className="small-medium text-right">{displayValue(value)}</p>
+          <p className="small-medium text-right">
+            {displayValue(value)} {unit}
+          </p>
         </td>
       ))}
     </tr>

--- a/frontend/src/components/SumRow.tsx
+++ b/frontend/src/components/SumRow.tsx
@@ -27,7 +27,7 @@ export function SumRow({
   return (
     <tr>
       <td colSpan={colSpan}>
-        <p className="small-medium text-black">{title}</p>
+        <p className="ml-3 small-medium text-black">{title}</p>
       </td>
       {values?.map((value, index) => (
         <td key={index} className="m-2 px-2 py-1 pt-3 gap-1">

--- a/frontend/src/components/SumRow.tsx
+++ b/frontend/src/components/SumRow.tsx
@@ -1,4 +1,4 @@
-export function ForecastSumRow({
+export function SumRow({
   title,
   values,
   minFractionDigits = 1,


### PR DESCRIPTION
A reusable _sum row_ component has been implemented, and is used for each sum row both on the staffing page and forecast page.

Six new sum rows have been added to the forecast page: _income_ and _realized hourly rate_ (_oppnådd timepris_) for both _Billable_ (_Ordre_), _Billable and offered_ (_Ordre, opsjon og tilbud_) and _Forecast_ (_Prognose_). The rows are collected in sections for an easier overview.

Some existing logic has also been simplified.
